### PR TITLE
Adapter: record CHAP human-decision events from Pydantic AI tool approvals

### DIFF
--- a/packages/chap-pydantic-ai/README.md
+++ b/packages/chap-pydantic-ai/README.md
@@ -1,0 +1,143 @@
+# chap-pydantic-ai
+
+Adapter between [Pydantic AI](https://ai.pydantic.dev) and the CHAP
+Coordinator. When a run pauses for tool approval, the human's
+decision -- approve, edit the arguments, or deny -- becomes a
+hash-linked, replayable CHAP audit entry.
+
+```
+Pydantic AI resolution            CHAP envelope
+------------------------          ---------------------------
+True / ToolApproved()             decide.approve
+ToolApproved(override_args=...)   decide.override   (diff of the args)
+False / ToolDenied(message=...)   decide.reject
+```
+
+The proposed tool call (tool name, validated args, `tool_call_id`) is
+the artefact under review; the resolution is the human's decision on it.
+An edited argument is recorded as an RFC 6902 diff, so the chain captures
+*what changed and why*, not just *approved/denied*.
+
+## Install
+
+```bash
+pip install chap-pydantic-ai
+```
+
+Depends on `chap-coordinator>=0.2.5`. Pydantic AI is **optional**: the
+adapter reads the resolution objects structurally, so the bridge and its
+tests work without it installed. Install the extra to run a live agent:
+
+```bash
+pip install "chap-pydantic-ai[pydantic-ai]"
+```
+
+## Quick start
+
+Pydantic AI surfaces human-in-the-loop through deferred tools. A tool
+marked `requires_approval=True` ends the run with a `DeferredToolRequests`
+output; you resolve each pending call into a `DeferredToolResults` and
+feed it back via `deferred_tool_results=`. The adapter records the
+decision at that resolution point:
+
+```python
+from pydantic_ai import Agent, DeferredToolRequests, DeferredToolResults, ToolApproved
+from chap_coordinator import Coordinator
+from chap_pydantic_ai import ChapApprovalBridge
+
+agent = Agent("openai:gpt-4o", output_type=[str, DeferredToolRequests])
+
+@agent.tool_plain(requires_approval=True)
+def transfer(amount: int, to: str) -> str:
+    return f"sent {amount} to {to}"
+
+bridge = ChapApprovalBridge(
+    Coordinator(),
+    workspace="wsp_payments",
+    agent="agent:assistant#v1",
+    reviewer="human:alice@example.org",
+)
+
+result = agent.run_sync("pay the invoice")
+if isinstance(result.output, DeferredToolRequests):
+    requests = result.output
+
+    # The human resolves each pending approval.
+    results = DeferredToolResults()
+    call = requests.approvals[0]
+    results.approvals[call.tool_call_id] = ToolApproved(
+        override_args={**call.args_as_dict(), "amount": 50},
+    )
+
+    # Record the decision, then let the agent finish.
+    bridge.record_results(requests, results)
+    result = agent.run_sync(
+        "pay the invoice",
+        message_history=result.all_messages(),
+        deferred_tool_results=results,
+    )
+```
+
+`record_results` walks `requests.approvals`, pairs each with its entry in
+`results.approvals`, and records one CHAP decision per call. The reviewer
+identity, rationale, tags, and the refine-vs-replace signal ride in
+`results.metadata[tool_call_id]`:
+
+```python
+results.metadata = {call.tool_call_id: {
+    "approver":         "human:sam@example.org",
+    "rationale":        "over the desk limit; capped to 50",
+    "tags":             ["limit-exceeded"],
+    "intent_preserved": True,   # same decision, smaller amount
+}}
+```
+
+To record a single decision directly, skip `record_results` and call
+`record_decision(call, resolution, **signal)`.
+
+## intent_preserved
+
+Editing arguments defaults to a refining override (`intent_preserved=true`):
+the human kept the decision and changed the inputs. That default is not
+always right -- sometimes an edit is a different decision in disguise -- so
+the reviewer can set `intent_preserved` explicitly through the metadata
+channel and the adapter records what they say.
+
+## Approver identity
+
+A decision record is only useful if it names who decided. CHAP has no
+ambient actor: the decider is whatever `from` the envelope carries. The
+bridge uses its `reviewer` by default, but a per-decision `approver` (set
+on the call or in `results.metadata`) overrides it, and the adapter joins
+that approver to the workspace before recording.
+
+## What you get in the audit chain
+
+One run with an edited approval yields:
+
+```
+seq=3  task.create     agent:assistant#v1
+seq=4  task.complete   agent:assistant#v1
+seq=5  review.request  agent:assistant#v1   to=human:sam@example.org
+seq=6  decide.override human:sam@example.org  diff=[{op:replace, path:/args/amount, value:50}]
+```
+
+Every entry carries `prev_hash`, so the chain verifies externally or
+anchors to a SCITT transparency service with the `audit-scitt/1.0`
+profile.
+
+## Example
+
+`examples/01-approve-edit-deny.py` drives one approval-gated tool through
+all three decisions using Pydantic AI's `TestModel` (offline, no API key)
+and prints the resulting chain.
+
+## Compatibility
+
+- `chap-coordinator` 0.2.5
+- `pydantic-ai` 1.x–2.x (optional; verified against 2.0)
+- Python 3.10, 3.11, 3.12, 3.13
+
+## License
+
+Apache 2.0. See [LICENSE](../../LICENSE).

--- a/packages/chap-pydantic-ai/chap_pydantic_ai/__init__.py
+++ b/packages/chap-pydantic-ai/chap_pydantic_ai/__init__.py
@@ -1,0 +1,317 @@
+"""
+chap-pydantic-ai: record a CHAP human-decision when a Pydantic AI run
+pauses for tool approval.
+
+Pydantic AI gates a tool with requires_approval=True (or an
+ApprovalRequiredToolset). The run then ends with a DeferredToolRequests
+output whose .approvals holds the pending ToolCallParts. The caller
+resolves each one into DeferredToolResults.approvals and feeds it back
+via deferred_tool_results=. This adapter records the decision at that
+resolution point:
+
+    Pydantic AI resolution            CHAP envelope
+    ------------------------          ---------------------------
+    True / ToolApproved()             decide.approve
+    ToolApproved(override_args=...)   decide.override  (diff of the args)
+    False / ToolDenied(message=...)   decide.reject
+
+The proposed tool call (tool name, args, tool_call_id) is the artefact
+under review; the resolution is the human's decision on it. Every
+envelope lands in the workspace audit chain, hash-linked and replayable.
+
+The bridge depends only on chap-coordinator. Pydantic AI is never
+imported here: the resolution objects are read structurally, so the same
+code runs against the real types or a test stand-in.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+from chap_coordinator import Coordinator
+
+
+__version__ = "0.2.5"
+
+
+def _make_envelope(method: str, params: dict) -> dict:
+    return {
+        "jsonrpc": "2.0",
+        "id":      f"chap-pydantic-ai-{method}",
+        "method":  method,
+        "params":  params,
+    }
+
+
+# ---- reading Pydantic AI objects without importing them --------------
+
+
+def _arguments(call: Any) -> dict:
+    """Pending args as a dict. ToolCallPart.args is str | dict | None;
+    args_as_dict() normalises it, so a model that emitted JSON text and
+    one that emitted a dict produce the same record."""
+    as_dict = getattr(call, "args_as_dict", None)
+    if callable(as_dict):
+        return as_dict()
+    args = getattr(call, "args", None)
+    if isinstance(args, str):
+        return json.loads(args) if args.strip() else {}
+    return dict(args) if args else {}
+
+
+def _override_args(resolution: Any) -> Optional[dict]:
+    """The edited args on a ToolApproved, or None. A bare True and a
+    ToolDenied have no such attribute, so they read as None."""
+    return getattr(resolution, "override_args", None)
+
+
+def _is_approved(resolution: Any) -> bool:
+    if resolution is True:
+        return True
+    if resolution is False:
+        return False
+    return hasattr(resolution, "override_args")  # ToolApproved
+
+
+def _denial_message(resolution: Any) -> str:
+    return getattr(resolution, "message", None) or "tool call denied by reviewer"
+
+
+def _participant_type(uri: str) -> str:
+    """CHAP participant type from the URI scheme: human:alice -> human,
+    agent:bot -> agent. The type then matches the identity instead of
+    being assumed."""
+    scheme = uri.split(":", 1)[0]
+    return scheme if scheme in ("human", "agent", "service", "group") else "human"
+
+
+# ---- RFC 6902 diff (the args edit, as a JSON Patch) ------------------
+
+
+def _escape(token: str) -> str:
+    return str(token).replace("~", "~0").replace("/", "~1")
+
+
+def _diff(before: Any, after: Any, path: str) -> list[dict]:
+    """Patch that turns `before` into `after`. Objects are walked
+    key-by-key; arrays and scalars are replaced whole. Keys are sorted so
+    the same edit always yields the same patch (it gets hashed into the
+    chain). Ported from the TypeScript coordinator's diffJsonPatch."""
+    if type(before) is not type(after) or not isinstance(before, dict):
+        return [] if before == after else [{"op": "replace", "path": path, "value": after}]
+    ops: list[dict] = []
+    for key in sorted(before.keys() | after.keys()):
+        at = f"{path}/{_escape(key)}"
+        if key not in after:
+            ops.append({"op": "remove", "path": at})
+        elif key not in before:
+            ops.append({"op": "add", "path": at, "value": after[key]})
+        else:
+            ops.extend(_diff(before[key], after[key], at))
+    return ops
+
+
+# ============================================================
+#   ChapApprovalBridge
+# ============================================================
+
+
+@dataclass
+class ChapApprovalBridge:
+    """One bridge per workspace. Holds the Coordinator, the workspace it
+    writes into, the agent that proposed the tool calls, and the default
+    approver. Share it across runs; pass a per-decision approver when the
+    decision belongs to someone else.
+    """
+
+    coord:     Coordinator
+    workspace: str
+    agent:     str
+    reviewer:  str
+    profiles:  tuple = ("core/1.0", "review/1.0")
+    # Lets tests / consumers observe every envelope before it reaches the
+    # Coordinator. Receives (method, params).
+    on_envelope: Optional[Callable[[str, dict], None]] = None
+
+    def __post_init__(self) -> None:
+        _safe_dispatch(self.coord, "workspace.create", {
+            "workspace": self.workspace,
+            "profiles":  list(self.profiles),
+        })
+        self._join(self.agent)
+        self._join(self.reviewer)
+
+    def record_decision(self, call: Any, resolution: Any, *,
+                        approver: Optional[str] = None,
+                        rationale: Optional[str] = None,
+                        tags: Optional[list[str]] = None,
+                        intent_preserved: Optional[bool] = None) -> str:
+        """Record one resolved approval and return the task id.
+
+        `call` is the pending ToolCallPart; `resolution` is what the
+        caller put in DeferredToolResults.approvals (bool, ToolApproved,
+        or ToolDenied). The keyword arguments are the human's signal that
+        the resolution object can't carry on its own -- a resolver lifts
+        them from DeferredToolResults.metadata[tool_call_id].
+        """
+        approver = approver or self.reviewer
+        if approver != self.reviewer:
+            self._join(approver)
+
+        args = _arguments(call)
+        artefact = {
+            "tool":         getattr(call, "tool_name", None),
+            "args":         args,
+            "tool_call_id": getattr(call, "tool_call_id", None),
+        }
+        task_id = self._submit(artefact, approver)
+
+        override = _override_args(resolution)
+        diff = _diff(args, override, "/args") if override is not None else None
+        if diff:
+            self._dispatch("decide.override", {
+                "workspace": self.workspace,
+                "from":      approver,
+                "task_id":   task_id,
+                "diff":      diff,
+                "rationale": rationale or "reviewer edited tool arguments",
+                "tags":      tags or [],
+                # Editing args is refining by default, but the reviewer can
+                # say otherwise: a different decision in disguise is not.
+                "intent_preserved": True if intent_preserved is None else intent_preserved,
+            })
+        elif _is_approved(resolution):
+            self._decide("decide.approve", approver, task_id, rationale, tags)
+        else:
+            self._decide("decide.reject", approver, task_id,
+                         rationale or _denial_message(resolution), tags)
+        return task_id
+
+    def record_results(self, requests: Any, results: Any) -> list[str]:
+        """Record every approval in a DeferredToolResults against the
+        DeferredToolRequests it answers. Rationale, tags, approver, and
+        intent_preserved are read per call from results.metadata. Returns
+        the task ids in request order.
+        """
+        meta = getattr(results, "metadata", None) or {}
+        task_ids = []
+        for call in requests.approvals:
+            cid = getattr(call, "tool_call_id", None)
+            if cid not in results.approvals:
+                raise ValueError(f"no resolution for pending approval {cid!r}")
+            signal = meta.get(cid, {})
+            task_ids.append(self.record_decision(
+                call, results.approvals[cid],
+                approver=signal.get("approver"),
+                rationale=signal.get("rationale"),
+                tags=signal.get("tags"),
+                intent_preserved=signal.get("intent_preserved"),
+            ))
+        return task_ids
+
+    def audit(self) -> list[dict]:
+        env = self._dispatch("audit.read", {"workspace": self.workspace})
+        return env["result"]["entries"]
+
+    # ---- internal -------------------------------------------------
+
+    def _submit(self, artefact: dict, approver: str) -> str:
+        """Open the task, record the agent's tool call as its output, and
+        send it for review -- the agent's half of the handshake."""
+        env = self._dispatch("task.create", {
+            "workspace": self.workspace,
+            "from":      self.agent,
+            "assignee":  self.agent,
+            "kind":      artefact["tool"] or "tool_call",
+            "input":     artefact,
+        })
+        task_id = env["result"]["task_id"]
+        self._dispatch("task.complete", {
+            "workspace": self.workspace,
+            "from":      self.agent,
+            "task_id":   task_id,
+            "output":    artefact,
+        })
+        self._dispatch("review.request", {
+            "workspace": self.workspace,
+            "from":      self.agent,
+            "task_id":   task_id,
+            "artefact":  artefact,
+            "to":        approver,
+        })
+        return task_id
+
+    def _decide(self, method: str, approver: str, task_id: str,
+                comment: Optional[str], tags: Optional[list[str]]) -> None:
+        # decide.approve / decide.reject record the reviewer's note as
+        # `comment` (decide.override is the one that takes `rationale`).
+        params: dict = {
+            "workspace": self.workspace,
+            "from":      approver,
+            "task_id":   task_id,
+        }
+        if comment:
+            params["comment"] = comment
+        if tags:
+            params["tags"] = tags
+        self._dispatch(method, params)
+
+    def _join(self, uri: str) -> None:
+        _safe_dispatch(self.coord, "participant.join", {
+            "workspace": self.workspace,
+            "from":      uri,
+            "type":      _participant_type(uri),
+        })
+
+    def _dispatch(self, method: str, params: dict) -> dict:
+        if self.on_envelope is not None:
+            self.on_envelope(method, params)
+        out = self.coord.dispatch(_make_envelope(method, params))
+        if out.get("error"):
+            err = out["error"]
+            raise ChapBridgeError(err.get("code", 0), err.get("message", ""))
+        return out
+
+
+# ============================================================
+#   Errors and helpers
+# ============================================================
+
+
+class ChapBridgeError(RuntimeError):
+    """Raised when the Coordinator rejects an envelope."""
+
+    def __init__(self, code: int, message: str) -> None:
+        super().__init__(f"CHAP error {code}: {message}")
+        self.code = code
+        self.message = message
+
+
+def _safe_dispatch(coord: Coordinator, method: str, params: dict) -> None:
+    """Dispatch, tolerating the errors that come from re-applying an
+    idempotent setup step (re-creating a workspace, re-joining a member).
+    Decide by checking the resulting state, not by matching the message;
+    anything else propagates."""
+    out = coord.dispatch(_make_envelope(method, params))
+    if not out.get("error"):
+        return
+
+    if method == "workspace.create":
+        ws_id = params.get("workspace")
+        if ws_id and ws_id in coord.workspaces:
+            return
+    elif method == "participant.join":
+        ws = coord.workspaces.get(params.get("workspace"))
+        if ws is not None and params.get("from") in ws.members:
+            return
+
+    raise ChapBridgeError(out["error"].get("code", 0),
+                          out["error"].get("message", ""))
+
+
+__all__ = [
+    "ChapApprovalBridge",
+    "ChapBridgeError",
+]

--- a/packages/chap-pydantic-ai/examples/01-approve-edit-deny.py
+++ b/packages/chap-pydantic-ai/examples/01-approve-edit-deny.py
@@ -55,8 +55,8 @@ def main() -> None:
     results.approvals[requests.approvals[0].tool_call_id] = ToolApproved()
     bridge.record_results(requests, results)
 
-    # 2. Approve, but cap the amount. The edit is the diff; a senior
-    #    reviewer signs it, and the metadata carries the why.
+    # 2. Refining edit: same decision, capped amount. intent_preserved
+    #    stays true (the default), and the metadata carries the why.
     requests = propose()
     call = requests.approvals[0]
     results = DeferredToolResults()
@@ -70,7 +70,23 @@ def main() -> None:
     }}
     bridge.record_results(requests, results)
 
-    # 3. Deny.
+    # 3. Substituting edit: the reviewer redirects the payment, a
+    #    different decision than the agent's, so intent_preserved=false.
+    requests = propose()
+    call = requests.approvals[0]
+    results = DeferredToolResults()
+    results.approvals[call.tool_call_id] = ToolApproved(
+        override_args={**call.args_as_dict(), "to": "acct-escrow"},
+    )
+    results.metadata = {call.tool_call_id: {
+        "approver":         "human:sam@example.org",
+        "rationale":        "wrong recipient; routed to escrow instead",
+        "tags":             ["wrong-recipient"],
+        "intent_preserved": False,
+    }}
+    bridge.record_results(requests, results)
+
+    # 4. Deny.
     requests = propose()
     results = DeferredToolResults()
     results.approvals[requests.approvals[0].tool_call_id] = ToolDenied(
@@ -86,7 +102,8 @@ def main() -> None:
         who = params.get("from", "")
         detail = ""
         if env["method"] == "decide.override":
-            detail = f"  diff={params['diff']} tags={params['tags']}"
+            detail = (f"  intent_preserved={params['intent_preserved']}"
+                      f" diff={params['diff']} tags={params['tags']}")
         elif env["method"] in ("decide.approve", "decide.reject"):
             detail = f"  {params.get('comment', '')}"
         print(f"  seq={entry['seq']:<2} {env['method']:<16} {who}{detail}")

--- a/packages/chap-pydantic-ai/examples/01-approve-edit-deny.py
+++ b/packages/chap-pydantic-ai/examples/01-approve-edit-deny.py
@@ -1,0 +1,96 @@
+"""
+Example: approve, edit, and deny one approval-gated Pydantic AI tool,
+and read the CHAP audit chain that results.
+
+Run (needs the optional Pydantic AI extra):
+    pip install -e ".[pydantic-ai]"
+    python3 examples/01-approve-edit-deny.py
+
+It uses Pydantic AI's TestModel, so it runs offline with no API key. The
+model proposes a `transfer` call; each run pauses for approval, and the
+bridge records the human's decision -- approve, edited args, or denial --
+as decide.approve / decide.override / decide.reject.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "coordinator-py"))
+
+from pydantic_ai import (
+    Agent, DeferredToolRequests, DeferredToolResults, ToolApproved, ToolDenied,
+)
+from pydantic_ai.models.test import TestModel
+
+from chap_coordinator import Coordinator
+from chap_pydantic_ai import ChapApprovalBridge
+
+
+agent = Agent(TestModel(), output_type=[str, DeferredToolRequests])
+
+
+@agent.tool_plain(requires_approval=True)
+def transfer(amount: int, to: str) -> str:
+    return f"sent {amount} to {to}"
+
+
+def propose() -> DeferredToolRequests:
+    """Run the agent until it pauses for approval, return the requests."""
+    return agent.run_sync("move some money").output
+
+
+def main() -> None:
+    coord = Coordinator()
+    bridge = ChapApprovalBridge(
+        coord,
+        workspace="wsp_payments",
+        agent="agent:assistant#v1",
+        reviewer="human:alice@example.org",
+    )
+
+    # 1. Approve as proposed.
+    requests = propose()
+    results = DeferredToolResults()
+    results.approvals[requests.approvals[0].tool_call_id] = ToolApproved()
+    bridge.record_results(requests, results)
+
+    # 2. Approve, but cap the amount. The edit is the diff; a senior
+    #    reviewer signs it, and the metadata carries the why.
+    requests = propose()
+    call = requests.approvals[0]
+    results = DeferredToolResults()
+    results.approvals[call.tool_call_id] = ToolApproved(
+        override_args={**call.args_as_dict(), "amount": 50},
+    )
+    results.metadata = {call.tool_call_id: {
+        "approver":  "human:sam@example.org",
+        "rationale": "over the desk limit; capped to 50",
+        "tags":      ["limit-exceeded"],
+    }}
+    bridge.record_results(requests, results)
+
+    # 3. Deny.
+    requests = propose()
+    results = DeferredToolResults()
+    results.approvals[requests.approvals[0].tool_call_id] = ToolDenied(
+        "recipient not on the allow-list",
+    )
+    bridge.record_results(requests, results)
+
+    print("Audit chain")
+    print("===========")
+    for entry in bridge.audit():
+        env = entry["envelope"]
+        params = env.get("params", {})
+        who = params.get("from", "")
+        detail = ""
+        if env["method"] == "decide.override":
+            detail = f"  diff={params['diff']} tags={params['tags']}"
+        elif env["method"] in ("decide.approve", "decide.reject"):
+            detail = f"  {params.get('comment', '')}"
+        print(f"  seq={entry['seq']:<2} {env['method']:<16} {who}{detail}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/chap-pydantic-ai/pyproject.toml
+++ b/packages/chap-pydantic-ai/pyproject.toml
@@ -1,0 +1,49 @@
+[build-system]
+requires      = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name            = "chap-pydantic-ai"
+version         = "0.2.5"
+description     = "CHAP adapter for Pydantic AI: record a human-decision envelope when a run pauses for tool approval."
+readme          = "README.md"
+requires-python = ">=3.10"
+license         = { text = "Apache-2.0" }
+authors         = [ { name = "Brightbeam AI", email = "oss@brightbeam.ai" } ]
+keywords        = ["chap", "pydantic-ai", "agent", "audit", "human-in-the-loop", "tool-approval"]
+classifiers     = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries",
+]
+dependencies = [
+    "chap-coordinator>=0.2.5",
+]
+
+[project.optional-dependencies]
+# Pydantic AI is only needed to run a live agent. The adapter reads the
+# resolution objects structurally, so the bridge and its tests work
+# without it installed.
+pydantic-ai = ["pydantic-ai>=1.0"]
+dev         = ["pytest>=8", "pytest-cov>=5"]
+
+[project.urls]
+Homepage      = "https://github.com/BrightbeamAI/chap"
+Repository    = "https://github.com/BrightbeamAI/chap"
+Specification = "https://github.com/BrightbeamAI/chap/blob/main/SPECIFICATION.md"
+
+[tool.setuptools.packages.find]
+include = ["chap_pydantic_ai*"]
+
+[tool.setuptools.package-data]
+"chap_pydantic_ai" = ["py.typed"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/packages/chap-pydantic-ai/tests/test_bridge.py
+++ b/packages/chap-pydantic-ai/tests/test_bridge.py
@@ -1,0 +1,270 @@
+"""
+Tests for chap-pydantic-ai. They run without Pydantic AI installed:
+the bridge reads the resolution objects structurally, so small stand-ins
+with the same attributes drive the same code path the real types would.
+
+    1. Agent proposes a tool call -> task.create + complete + review.request.
+    2. Human resolves it -> decide.approve | decide.override | decide.reject.
+    3. The audit chain carries the whole trail, hash-linked.
+"""
+
+import sys
+from pathlib import Path
+
+THIS = Path(__file__).resolve()
+sys.path.insert(0, str(THIS.parents[1]))
+sys.path.insert(0, str(THIS.parents[2] / "coordinator-py"))
+
+import pytest
+
+from chap_coordinator import Coordinator, CoordinatorOptions
+from chap_pydantic_ai import ChapApprovalBridge, ChapBridgeError
+
+
+# ---- Pydantic AI stand-ins -----------------------------------------
+
+
+class Call:
+    """A ToolCallPart with args already a dict (args_as_dict present)."""
+
+    def __init__(self, tool_name, args, tool_call_id):
+        self.tool_name = tool_name
+        self._args = args
+        self.tool_call_id = tool_call_id
+
+    def args_as_dict(self):
+        return dict(self._args)
+
+
+class RawCall:
+    """A ToolCallPart whose args arrived as a JSON string and which has no
+    args_as_dict() -- exercises the coercion fallback."""
+
+    def __init__(self, tool_name, args_json, tool_call_id):
+        self.tool_name = tool_name
+        self.args = args_json
+        self.tool_call_id = tool_call_id
+
+
+class ToolApproved:
+    def __init__(self, override_args=None):
+        self.override_args = override_args
+
+
+class ToolDenied:
+    def __init__(self, message="The tool call was denied."):
+        self.message = message
+
+
+class Requests:
+    def __init__(self, approvals):
+        self.approvals = approvals
+
+
+class Results:
+    def __init__(self, approvals, metadata=None):
+        self.approvals = approvals
+        self.metadata = metadata or {}
+
+
+# ---- fixtures ------------------------------------------------------
+
+
+@pytest.fixture
+def coord():
+    return Coordinator(CoordinatorOptions(
+        deterministic_ids=True, deterministic_clock=True, enable_chain=True,
+    ))
+
+
+@pytest.fixture
+def bridge(coord):
+    return ChapApprovalBridge(
+        coord,
+        workspace="wsp_pai_test",
+        agent="agent:assistant#v1",
+        reviewer="human:alice@example.org",
+    )
+
+
+def methods(bridge):
+    return [e["envelope"]["method"] for e in bridge.audit()]
+
+
+def last_params(bridge, method):
+    for entry in reversed(bridge.audit()):
+        if entry["envelope"]["method"] == method:
+            return entry["envelope"]["params"]
+    raise AssertionError(f"no {method} in audit")
+
+
+# ---- setup ---------------------------------------------------------
+
+
+def test_bridge_joins_agent_and_reviewer(coord, bridge):
+    ws = coord.workspaces["wsp_pai_test"]
+    assert "agent:assistant#v1" in ws.members
+    assert "human:alice@example.org" in ws.members
+
+
+def test_bridge_is_idempotent(coord, bridge):
+    ChapApprovalBridge(
+        coord, workspace="wsp_pai_test",
+        agent="agent:assistant#v1", reviewer="human:alice@example.org",
+    )
+    assert len(coord.workspaces["wsp_pai_test"].members) == 2
+
+
+# ---- the three decisions -------------------------------------------
+
+
+def test_approve(bridge):
+    seen = []
+    bridge.on_envelope = lambda m, p: seen.append(m)
+    bridge.record_decision(Call("send_email", {"to": "x@y.z"}, "c1"), ToolApproved())
+
+    assert seen == ["task.create", "task.complete", "review.request", "decide.approve"]
+    assert methods(bridge)[-1] == "decide.approve"
+
+
+def test_approve_via_bool(bridge):
+    bridge.record_decision(Call("send_email", {"to": "x@y.z"}, "c1"), True)
+    assert methods(bridge)[-1] == "decide.approve"
+
+
+def test_deny_records_message_as_comment(bridge):
+    bridge.record_decision(Call("delete_file", {"path": "/etc/x"}, "c1"),
+                           ToolDenied("deleting files is not allowed"))
+    params = last_params(bridge, "decide.reject")
+    assert params["comment"] == "deleting files is not allowed"
+
+
+def test_deny_via_bool_uses_default_message(bridge):
+    bridge.record_decision(Call("delete_file", {"path": "/etc/x"}, "c1"), False)
+    assert last_params(bridge, "decide.reject")["comment"]
+
+
+def test_override_diffs_only_the_changed_field(bridge):
+    bridge.record_decision(
+        Call("transfer", {"amount": 100, "to": "acct-9"}, "c1"),
+        ToolApproved(override_args={"amount": 50, "to": "acct-9"}),
+        rationale="cap to 50", tags=["limit"],
+    )
+    params = last_params(bridge, "decide.override")
+    assert params["diff"] == [{"op": "replace", "path": "/args/amount", "value": 50}]
+    assert params["rationale"] == "cap to 50"
+    assert params["tags"] == ["limit"]
+
+
+def test_override_intent_preserved_defaults_true(bridge):
+    bridge.record_decision(
+        Call("transfer", {"amount": 100}, "c1"),
+        ToolApproved(override_args={"amount": 50}),
+    )
+    assert last_params(bridge, "decide.override")["intent_preserved"] is True
+
+
+def test_override_with_no_actual_change_is_an_approve(bridge):
+    # override_args identical to the original is not an edit; recording it
+    # as an override would be a phantom in the "overrides as data" view.
+    bridge.record_decision(
+        Call("transfer", {"amount": 100}, "c1"),
+        ToolApproved(override_args={"amount": 100}),
+    )
+    assert methods(bridge)[-1] == "decide.approve"
+
+
+def test_override_intent_preserved_can_be_overridden(bridge):
+    bridge.record_decision(
+        Call("transfer", {"amount": 100}, "c1"),
+        ToolApproved(override_args={"amount": 50}),
+        intent_preserved=False,
+    )
+    assert last_params(bridge, "decide.override")["intent_preserved"] is False
+
+
+# ---- identity ------------------------------------------------------
+
+
+def test_per_decision_approver_is_joined_and_recorded(coord, bridge):
+    bridge.record_decision(
+        Call("ship", {"env": "prod"}, "c1"), ToolApproved(),
+        approver="human:bob@example.org",
+    )
+    assert "human:bob@example.org" in coord.workspaces["wsp_pai_test"].members
+    assert last_params(bridge, "decide.approve")["from"] == "human:bob@example.org"
+
+
+def test_member_type_follows_the_uri_scheme(coord, bridge):
+    bridge.record_decision(
+        Call("ship", {"env": "prod"}, "c1"), ToolApproved(),
+        approver="service:autodeploy",
+    )
+    ws = coord.workspaces["wsp_pai_test"]
+    assert ws.members["service:autodeploy"].type == "service"
+    assert ws.members["agent:assistant#v1"].type == "agent"
+    assert ws.members["human:alice@example.org"].type == "human"
+
+
+# ---- args coercion -------------------------------------------------
+
+
+def test_stringified_args_are_normalised(bridge):
+    bridge.record_decision(RawCall("send_email", '{"to": "x@y.z"}', "c1"), ToolApproved())
+    artefact = last_params(bridge, "review.request")["artefact"]
+    assert artefact["args"] == {"to": "x@y.z"}
+
+
+# ---- record_results ------------------------------------------------
+
+
+def test_record_results_raises_on_unresolved_approval(bridge):
+    requests = Requests([Call("send_email", {"to": "x@y.z"}, "c1")])
+    results = Results(approvals={})  # caller forgot to resolve c1
+    with pytest.raises(ValueError, match="no resolution"):
+        bridge.record_results(requests, results)
+
+
+def test_record_results_walks_requests_and_metadata(bridge):
+    requests = Requests([
+        Call("send_email", {"to": "x@y.z"}, "c1"),
+        Call("transfer", {"amount": 100}, "c2"),
+    ])
+    results = Results(
+        approvals={"c1": ToolApproved(), "c2": ToolApproved(override_args={"amount": 50})},
+        metadata={"c2": {"approver": "human:bob@example.org",
+                         "rationale": "cap to 50", "tags": ["limit"]}},
+    )
+    bridge.record_results(requests, results)
+
+    ms = methods(bridge)
+    assert ms[-1] == "decide.override"
+    assert "decide.approve" in ms
+    ov = last_params(bridge, "decide.override")
+    assert ov["from"] == "human:bob@example.org"
+    assert ov["tags"] == ["limit"]
+
+
+# ---- chain ---------------------------------------------------------
+
+
+def test_chain_is_hash_linked(bridge):
+    bridge.record_decision(Call("send_email", {"to": "x@y.z"}, "c1"), ToolApproved())
+    bridge.record_decision(Call("rm", {"path": "/x"}, "c2"), ToolDenied("no"))
+    audit = bridge.audit()
+    assert len(audit) >= 8
+    assert all("prev_hash" in e for e in audit)
+
+
+# ---- errors --------------------------------------------------------
+
+
+def test_coordinator_error_surfaces(bridge):
+    # A decision on a task that was never opened is rejected by the
+    # Coordinator and reaches the caller as a ChapBridgeError.
+    with pytest.raises(ChapBridgeError):
+        bridge._dispatch("decide.approve", {
+            "workspace": bridge.workspace,
+            "from": bridge.reviewer,
+            "task_id": "tsk_does_not_exist",
+        })


### PR DESCRIPTION
Closes #2.

A small adapter mirroring `chap-langgraph`: when a Pydantic AI run pauses for tool approval, the human's decision becomes a CHAP envelope.

```
True / ToolApproved()             -> decide.approve
ToolApproved(override_args=...)    -> decide.override   (RFC 6902 diff of the args)
False / ToolDenied(message=...)   -> decide.reject
```

The pending `ToolCallPart` (tool, validated args, `tool_call_id`) is the artefact under review; the resolution is the human's decision on it. Targets the stable `deferred_tool_results` path rather than the inline hook while pydantic-ai/pydantic-ai#3959 settles.

### Addressing the review

- **`intent_preserved` is not hardcoded.** It defaults to `true` for an args edit but the resolver can override it, via `results.metadata[tool_call_id]` — the same channel that carries `rationale` and `tags`. Refine-vs-replace stays the human's signal.
- **Approver identity flows into every record.** The Coordinator has no ambient actor: the decider is the envelope `from`, which it stamps onto `decisions[].reviewer`, the override artefact, and task history. The bridge takes a default `reviewer` but a per-decision `approver` overrides it; the participant type is derived from the URI scheme and the approver is joined just-in-time. The example uses real named approvers (alice approves/denies, sam signs the capped override).

### Design notes

- `pydantic-ai` is an **optional** dependency. The resolution objects are read structurally, so the bridge and its tests run without it installed.
- `comment` is used for `decide.approve`/`decide.reject` and `rationale` for `decide.override` — the field each handler actually records.
- A no-op override (`override_args` equal to the original args) records an `approve`, not an empty-diff override, so it doesn't show up as a phantom in the overrides view.

### Verification

- 17 unit tests pass with no `pydantic-ai` installed (structural stand-ins).
- `examples/01-approve-edit-deny.py` runs all three decisions against real pydantic-ai 2.0 using `TestModel` (offline, no API key); resuming with the override confirms the edited args take effect. The emitted chain is hash-linked and accepted by a conformant Coordinator. Happy to add an explicit harness-binary run against a live server if you'd like that demonstrated literally rather than by construction.

### Two spec things worth a look (not changed here)

- `decide.approve`/`decide.reject` record the reviewer's note as `comment`, while `decide.override` uses `rationale` — two field names for "the why."
- `decide.*` don't verify `from` is a *joined member* (only workspace/task existence and `review_requested` state), so a decision could currently name a non-member.

### Files

```
packages/chap-pydantic-ai/
  pyproject.toml
  chap_pydantic_ai/__init__.py
  chap_pydantic_ai/py.typed
  examples/01-approve-edit-deny.py
  tests/test_bridge.py
  README.md
```
