### PR TITLE
Adapter: record CHAP human-decision events from LlamaIndex Workflows human-in-the-loop

### DIFF
--- a/packages/chap-llama-index/README.md
+++ b/packages/chap-llama-index/README.md
@@ -1,0 +1,124 @@
+# chap-llama-index
+
+Adapter between [LlamaIndex Workflows](https://developers.llamaindex.ai/python/framework/understanding/workflows/)
+and the CHAP Coordinator. When a workflow step pauses for human input,
+the human's decision -- approve, edit, or reject -- becomes a hash-linked,
+replayable CHAP audit entry.
+
+```
+decision      CHAP envelope
+--------      ---------------------------
+approve       decide.approve
+override      decide.override   (proposed vs returned, as a diff)
+reject        decide.reject
+```
+
+The proposed output on the `InputRequiredEvent` is the artefact under
+review; the human's `HumanResponseEvent` is the decision on it. An edit is
+recorded as an RFC 6902 diff, so the chain captures *what changed and why*,
+not just *approved/rejected*.
+
+## Install
+
+```bash
+pip install chap-llama-index
+```
+
+Depends on `chap-coordinator>=0.2.5`. LlamaIndex is **optional**: the
+adapter reads events structurally, so the bridge and its tests work
+without it installed. Install the extra to run a live workflow:
+
+```bash
+pip install "chap-llama-index[llama-index]"
+```
+
+## Quick start
+
+Workflows surface human-in-the-loop as events: a step returns an
+`InputRequiredEvent` and waits; a second step consumes the matching
+`HumanResponseEvent`. The driver that answers the pause is where both
+events meet, so that is where the decision is recorded:
+
+```python
+from workflows.events import InputRequiredEvent, HumanResponseEvent
+from chap_coordinator import Coordinator
+from chap_llama_index import ChapHitlBridge
+
+bridge = ChapHitlBridge(
+    Coordinator(),
+    workspace="wsp_payments",
+    agent="agent:writer#v1",
+    reviewer="human:alice@example.org",
+)
+
+handler = workflow.run()
+async for event in handler.stream_events():
+    if isinstance(event, InputRequiredEvent):
+        response = HumanResponseEvent(
+            response={"amount": 50, "to": "acct-9"},   # the edited output
+            decision="override",
+            user_name="human:sam@example.org",
+            rationale="over the desk limit; capped to 50",
+            tags=["limit-exceeded"],
+        )
+        bridge.record_decision(event, response, decision=response.get("decision"))
+        handler.ctx.send_event(response)
+await handler
+```
+
+## Decision is explicit
+
+Workflows events are schemaless and carry no approve/edit/reject signal,
+so `decision` is a required argument -- the adapter never guesses intent
+from the response text. `proposed`, `returned`, `rationale`, `tags`,
+`intent_preserved`, and `approver` default to fields read off the events
+(`event.get(...)`) and can each be overridden per call:
+
+```python
+bridge.record_decision(input_event, response_event, decision="approve")
+```
+
+`intent_preserved` defaults to `true` on an override (a refining edit);
+set it `false` on the response for a substituting edit -- a different
+decision, not a refinement.
+
+## Approver identity
+
+CHAP has no ambient actor: the decider is whatever `from` the envelope
+carries. The bridge uses its `reviewer` by default, but the
+`HumanResponseEvent`'s `user_name` (or an explicit `approver=`) overrides
+it, and the adapter joins that approver -- with a participant type taken
+from the URI scheme -- before recording. Each decision is its own task
+whose review is addressed to that approver, so the record satisfies the
+Coordinator's authorisation rules.
+
+## What you get in the audit chain
+
+One paused step with an edit yields:
+
+```
+seq=3  task.create     agent:writer#v1
+seq=4  task.complete   agent:writer#v1
+seq=5  review.request  agent:writer#v1   to=human:sam@example.org
+seq=6  decide.override human:sam@example.org  diff=[{op:replace, path:/amount, value:50}]
+```
+
+Every entry carries `prev_hash`, so the chain verifies externally or
+anchors to a SCITT transparency service with the `audit-scitt/1.0`
+profile.
+
+## Example
+
+`examples/01-approve-edit-reject.py` drives one paused workflow through
+approve, a refining edit, a substituting edit, and a reject against real
+`llama-index-workflows`, and prints the resulting chain.
+
+## Compatibility
+
+- `chap-coordinator` 0.2.6
+- `llama-index-workflows` 1.x–2.x (optional; verified against 2.22)
+- Python 3.10, 3.11, 3.12, 3.13
+
+## License
+
+Apache 2.0. See [LICENSE](../../LICENSE).

--- a/packages/chap-llama-index/chap_llama_index/__init__.py
+++ b/packages/chap-llama-index/chap_llama_index/__init__.py
@@ -156,6 +156,8 @@ class ChapHitlBridge:
             if returned is None:
                 returned = _event_get(response_event, "response")
             if diff is None:
+                if returned is None:
+                    raise ValueError("an override needs `returned` content (or a `diff`)")
                 diff = _diff(proposed, returned, "")
             if not diff:
                 # The edit changed nothing; record the approve it really is.

--- a/packages/chap-llama-index/chap_llama_index/__init__.py
+++ b/packages/chap-llama-index/chap_llama_index/__init__.py
@@ -1,0 +1,287 @@
+"""
+chap-llama-index: record a CHAP human-decision when a LlamaIndex Workflow
+pauses for human input.
+
+A Workflow step returns an InputRequiredEvent carrying the proposed
+output and waits; a human replies with a HumanResponseEvent. This adapter
+records that reply against the proposed output:
+
+    decision      CHAP envelope
+    --------      ---------------------------
+    approve       decide.approve
+    override      decide.override  (proposed vs returned, as a diff)
+    reject        decide.reject
+
+Workflows events are schemaless and carry no approve/edit/reject signal,
+so the decision is passed in explicitly. The returned content, rationale,
+tags, and the approver are read off the HumanResponseEvent by convention,
+each overridable with a keyword argument.
+
+The bridge depends only on chap-coordinator. llama-index-workflows is
+never imported here: events are read structurally via event.get(...), so
+the same code runs against the real types or a test stand-in.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+from chap_coordinator import Coordinator
+
+
+__version__ = "0.2.6"
+
+
+def _make_envelope(method: str, params: dict) -> dict:
+    return {
+        "jsonrpc": "2.0",
+        "id":      f"chap-llama-index-{method}",
+        "method":  method,
+        "params":  params,
+    }
+
+
+# ---- reading Workflows events without importing them -----------------
+
+
+def _event_get(event: Any, key: str, default: Any = None) -> Any:
+    """Read a field off a Workflows event. Its Event is a DictLikeModel,
+    so dynamic fields come through .get(); a plain stand-in falls back to
+    attribute access."""
+    getter = getattr(event, "get", None)
+    if callable(getter):
+        return getter(key, default)
+    return getattr(event, key, default)
+
+
+def _payload(event: Any) -> dict:
+    to_dict = getattr(event, "to_dict", None)
+    return to_dict() if callable(to_dict) else {}
+
+
+# ---- RFC 6902 diff (proposed -> returned, as a JSON Patch) -----------
+
+
+def _escape(token: str) -> str:
+    return str(token).replace("~", "~0").replace("/", "~1")
+
+
+def _diff(before: Any, after: Any, path: str) -> list[dict]:
+    """Patch that turns `before` into `after`. Objects are walked
+    key-by-key; arrays and scalars are replaced whole. Keys are sorted so
+    the same edit always yields the same patch (it gets hashed into the
+    chain). Ported from the TypeScript coordinator's diffJsonPatch."""
+    if type(before) is not type(after) or not isinstance(before, dict):
+        return [] if before == after else [{"op": "replace", "path": path, "value": after}]
+    ops: list[dict] = []
+    for key in sorted(before.keys() | after.keys()):
+        at = f"{path}/{_escape(key)}"
+        if key not in after:
+            ops.append({"op": "remove", "path": at})
+        elif key not in before:
+            ops.append({"op": "add", "path": at, "value": after[key]})
+        else:
+            ops.extend(_diff(before[key], after[key], at))
+    return ops
+
+
+def _participant_type(uri: str) -> str:
+    scheme = uri.split(":", 1)[0]
+    return scheme if scheme in ("human", "agent", "service", "group") else "human"
+
+
+# ============================================================
+#   ChapHitlBridge
+# ============================================================
+
+
+@dataclass
+class ChapHitlBridge:
+    """One bridge per workspace. Holds the Coordinator, the workspace it
+    writes into, the agent whose step proposed the output, and the default
+    approver. Share it across runs; pass a per-decision approver when the
+    decision belongs to someone else.
+    """
+
+    coord:     Coordinator
+    workspace: str
+    agent:     str
+    reviewer:  str
+    profiles:  tuple = ("core/1.0", "review/1.0")
+    on_envelope: Optional[Callable[[str, dict], None]] = None
+
+    def __post_init__(self) -> None:
+        _safe_dispatch(self.coord, "workspace.create", {
+            "workspace": self.workspace,
+            "profiles":  list(self.profiles),
+        })
+        self._join(self.agent)
+        self._join(self.reviewer)
+
+    def record_decision(self, input_event: Any, response_event: Any, *,
+                        decision: str,
+                        proposed: Any = None,
+                        returned: Any = None,
+                        diff: Optional[list[dict]] = None,
+                        rationale: Optional[str] = None,
+                        tags: Optional[list[str]] = None,
+                        intent_preserved: Optional[bool] = None,
+                        approver: Optional[str] = None) -> str:
+        """Record one human decision and return the task id.
+
+        `input_event` is the InputRequiredEvent that paused the step;
+        `response_event` is the HumanResponseEvent that answered it.
+        `decision` is required and authoritative -- Workflows events carry
+        no approve/edit/reject signal to infer from. `proposed`, `returned`,
+        `rationale`, `tags`, `intent_preserved`, and `approver` default to
+        fields read off the events and can be overridden per call.
+        """
+        approver = approver or _event_get(response_event, "user_name") or self.reviewer
+        if approver != self.reviewer:
+            self._join(approver)
+
+        if proposed is None:
+            proposed = _event_get(input_event, "proposed") or _payload(input_event)
+        if rationale is None:
+            rationale = _event_get(response_event, "rationale")
+        if tags is None:
+            tags = _event_get(response_event, "tags")
+
+        task_id = self._submit(proposed, approver)
+
+        if decision == "approve":
+            self._decide("decide.approve", approver, task_id, rationale, tags)
+        elif decision == "override":
+            if returned is None:
+                returned = _event_get(response_event, "response")
+            if diff is None:
+                diff = _diff(proposed, returned, "")
+            if not diff:
+                # The edit changed nothing; record the approve it really is.
+                self._decide("decide.approve", approver, task_id, rationale, tags)
+                return task_id
+            if intent_preserved is None:
+                intent_preserved = _event_get(response_event, "intent_preserved")
+            self._dispatch("decide.override", {
+                "workspace": self.workspace,
+                "from":      approver,
+                "task_id":   task_id,
+                "diff":      diff,
+                "rationale": rationale or "reviewer edited the output",
+                "tags":      tags or [],
+                "intent_preserved": True if intent_preserved is None else intent_preserved,
+            })
+        elif decision == "reject":
+            note = rationale or _event_get(response_event, "response")
+            self._decide("decide.reject", approver, task_id, note, tags)
+        else:
+            raise ValueError(
+                f"decision must be 'approve', 'override', or 'reject': {decision!r}"
+            )
+        return task_id
+
+    def audit(self) -> list[dict]:
+        env = self._dispatch("audit.read", {"workspace": self.workspace})
+        return env["result"]["entries"]
+
+    # ---- internal -------------------------------------------------
+
+    def _submit(self, artefact: Any, approver: str) -> str:
+        """Record the proposed output as the agent's task output and send
+        it for review -- the agent's half of the handshake."""
+        env = self._dispatch("task.create", {
+            "workspace": self.workspace,
+            "from":      self.agent,
+            "assignee":  self.agent,
+            "kind":      "workflow_output",
+            "input":     artefact,
+        })
+        task_id = env["result"]["task_id"]
+        self._dispatch("task.complete", {
+            "workspace": self.workspace,
+            "from":      self.agent,
+            "task_id":   task_id,
+            "output":    artefact,
+        })
+        self._dispatch("review.request", {
+            "workspace": self.workspace,
+            "from":      self.agent,
+            "task_id":   task_id,
+            "artefact":  artefact,
+            "to":        approver,
+        })
+        return task_id
+
+    def _decide(self, method: str, approver: str, task_id: str,
+                comment: Optional[str], tags: Optional[list[str]]) -> None:
+        # decide.approve / decide.reject record the reviewer's note as
+        # `comment` (decide.override is the one that takes `rationale`).
+        params: dict = {
+            "workspace": self.workspace,
+            "from":      approver,
+            "task_id":   task_id,
+        }
+        if comment:
+            params["comment"] = comment
+        if tags:
+            params["tags"] = tags
+        self._dispatch(method, params)
+
+    def _join(self, uri: str) -> None:
+        _safe_dispatch(self.coord, "participant.join", {
+            "workspace": self.workspace,
+            "from":      uri,
+            "type":      _participant_type(uri),
+        })
+
+    def _dispatch(self, method: str, params: dict) -> dict:
+        if self.on_envelope is not None:
+            self.on_envelope(method, params)
+        out = self.coord.dispatch(_make_envelope(method, params))
+        if out.get("error"):
+            err = out["error"]
+            raise ChapBridgeError(err.get("code", 0), err.get("message", ""))
+        return out
+
+
+# ============================================================
+#   Errors and helpers
+# ============================================================
+
+
+class ChapBridgeError(RuntimeError):
+    """Raised when the Coordinator rejects an envelope."""
+
+    def __init__(self, code: int, message: str) -> None:
+        super().__init__(f"CHAP error {code}: {message}")
+        self.code = code
+        self.message = message
+
+
+def _safe_dispatch(coord: Coordinator, method: str, params: dict) -> None:
+    """Dispatch, tolerating the errors that come from re-applying an
+    idempotent setup step (re-creating a workspace, re-joining a member).
+    Decide by checking the resulting state, not by matching the message;
+    anything else propagates."""
+    out = coord.dispatch(_make_envelope(method, params))
+    if not out.get("error"):
+        return
+
+    if method == "workspace.create":
+        ws_id = params.get("workspace")
+        if ws_id and ws_id in coord.workspaces:
+            return
+    elif method == "participant.join":
+        ws = coord.workspaces.get(params.get("workspace"))
+        if ws is not None and params.get("from") in ws.members:
+            return
+
+    raise ChapBridgeError(out["error"].get("code", 0),
+                          out["error"].get("message", ""))
+
+
+__all__ = [
+    "ChapHitlBridge",
+    "ChapBridgeError",
+]

--- a/packages/chap-llama-index/examples/01-approve-edit-reject.py
+++ b/packages/chap-llama-index/examples/01-approve-edit-reject.py
@@ -1,0 +1,100 @@
+"""
+Example: approve, edit, and reject one LlamaIndex Workflow step that
+pauses for human input, and read the CHAP audit chain that results.
+
+Run (needs the optional LlamaIndex extra):
+    pip install -e ".[llama-index]"
+    python3 examples/01-approve-edit-reject.py
+
+The workflow proposes a payment and pauses on an InputRequiredEvent. The
+driver streams events, records each human decision through the bridge,
+and sends a HumanResponseEvent back to resume the run -- as
+decide.approve / decide.override / decide.reject.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "coordinator-py"))
+
+from workflows import Context, Workflow, step
+from workflows.events import (
+    HumanResponseEvent, InputRequiredEvent, StartEvent, StopEvent,
+)
+
+from chap_coordinator import Coordinator
+from chap_llama_index import ChapHitlBridge
+
+
+PROPOSED = {"amount": 100, "to": "acct-9"}
+
+
+class PaymentReview(Workflow):
+    @step
+    async def propose(self, ctx: Context, ev: StartEvent) -> InputRequiredEvent:
+        return InputRequiredEvent(prefix="approve payment? ", proposed=PROPOSED)
+
+    @step
+    async def resume(self, ctx: Context, ev: HumanResponseEvent) -> StopEvent:
+        return StopEvent(result=ev.get("response"))
+
+
+async def run_once(bridge: ChapHitlBridge, response: HumanResponseEvent) -> None:
+    """Drive the workflow to its pause, record the decision, resume it."""
+    handler = PaymentReview(timeout=30).run()
+    async for event in handler.stream_events():
+        if isinstance(event, InputRequiredEvent):
+            bridge.record_decision(event, response, decision=response.get("decision"))
+            handler.ctx.send_event(response)
+    await handler
+
+
+async def main() -> None:
+    coord = Coordinator()
+    bridge = ChapHitlBridge(
+        coord,
+        workspace="wsp_payments",
+        agent="agent:writer#v1",
+        reviewer="human:alice@example.org",
+    )
+
+    # Approve as proposed.
+    await run_once(bridge, HumanResponseEvent(response="ok", decision="approve"))
+
+    # Refining edit: cap the amount, same decision -> intent_preserved true.
+    await run_once(bridge, HumanResponseEvent(
+        response={**PROPOSED, "amount": 50}, decision="override",
+        user_name="human:sam@example.org",
+        rationale="over the desk limit; capped to 50", tags=["limit-exceeded"]))
+
+    # Substituting edit: redirect the payment, a different decision, so
+    # intent_preserved is false.
+    await run_once(bridge, HumanResponseEvent(
+        response={**PROPOSED, "to": "acct-escrow"}, decision="override",
+        user_name="human:sam@example.org",
+        rationale="wrong recipient; routed to escrow instead",
+        tags=["wrong-recipient"], intent_preserved=False))
+
+    # Reject.
+    await run_once(bridge, HumanResponseEvent(
+        response="recipient not on the allow-list", decision="reject"))
+
+    print("Audit chain")
+    print("===========")
+    for entry in bridge.audit():
+        env = entry["envelope"]
+        params = env.get("params", {})
+        who = params.get("from", "")
+        detail = ""
+        if env["method"] == "decide.override":
+            detail = (f"  intent_preserved={params['intent_preserved']}"
+                      f" diff={params['diff']} tags={params['tags']}")
+        elif env["method"] in ("decide.approve", "decide.reject"):
+            detail = f"  {params.get('comment', '')}"
+        print(f"  seq={entry['seq']:<2} {env['method']:<16} {who}{detail}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/chap-llama-index/pyproject.toml
+++ b/packages/chap-llama-index/pyproject.toml
@@ -1,0 +1,49 @@
+[build-system]
+requires      = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name            = "chap-llama-index"
+version         = "0.2.6"
+description      = "CHAP adapter for LlamaIndex Workflows: record a human-decision envelope when a step pauses for human input."
+readme          = "README.md"
+requires-python = ">=3.10"
+license         = { text = "Apache-2.0" }
+authors         = [ { name = "Brightbeam AI", email = "oss@brightbeam.ai" } ]
+keywords        = ["chap", "llama-index", "workflows", "agent", "audit", "human-in-the-loop"]
+classifiers     = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries",
+]
+dependencies = [
+    "chap-coordinator>=0.2.5",
+]
+
+[project.optional-dependencies]
+# LlamaIndex Workflows is only needed to run a live workflow. The adapter
+# reads the events structurally, so the bridge and its tests work without
+# it installed.
+llama-index = ["llama-index-workflows>=1.0"]
+dev         = ["pytest>=8", "pytest-cov>=5"]
+
+[project.urls]
+Homepage      = "https://github.com/BrightbeamAI/chap"
+Repository    = "https://github.com/BrightbeamAI/chap"
+Specification = "https://github.com/BrightbeamAI/chap/blob/main/SPECIFICATION.md"
+
+[tool.setuptools.packages.find]
+include = ["chap_llama_index*"]
+
+[tool.setuptools.package-data]
+"chap_llama_index" = ["py.typed"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/packages/chap-llama-index/tests/test_bridge.py
+++ b/packages/chap-llama-index/tests/test_bridge.py
@@ -149,6 +149,11 @@ def test_unknown_decision_raises(bridge):
         bridge.record_decision(ask({"x": 1}), reply(response="?"), decision="maybe")
 
 
+def test_override_without_returned_content_raises(bridge):
+    with pytest.raises(ValueError, match="returned"):
+        bridge.record_decision(ask({"x": 1}), reply(), decision="override")
+
+
 def test_chain_is_hash_linked(bridge):
     bridge.record_decision(ask({"x": 1}), reply(response="ok"), decision="approve")
     bridge.record_decision(ask({"x": 2}), reply(response="no"), decision="reject")

--- a/packages/chap-llama-index/tests/test_bridge.py
+++ b/packages/chap-llama-index/tests/test_bridge.py
@@ -1,0 +1,166 @@
+"""
+Tests for chap-llama-index. They run without llama-index-workflows: the
+bridge reads events via event.get(...), so a plain dict stands in for an
+InputRequiredEvent or HumanResponseEvent.
+
+    1. A step proposes output -> task.create + complete + review.request.
+    2. A human answers -> decide.approve | decide.override | decide.reject.
+    3. The audit chain carries the whole trail, hash-linked.
+"""
+
+import sys
+from pathlib import Path
+
+THIS = Path(__file__).resolve()
+sys.path.insert(0, str(THIS.parents[1]))
+sys.path.insert(0, str(THIS.parents[2] / "coordinator-py"))
+
+import pytest
+
+from chap_coordinator import Coordinator, CoordinatorOptions
+from chap_llama_index import ChapHitlBridge, ChapBridgeError
+
+
+def ask(proposed, **extra):
+    return {"proposed": proposed, **extra}
+
+
+def reply(**fields):
+    return dict(fields)
+
+
+@pytest.fixture
+def coord():
+    return Coordinator(CoordinatorOptions(
+        deterministic_ids=True, deterministic_clock=True, enable_chain=True,
+    ))
+
+
+@pytest.fixture
+def bridge(coord):
+    return ChapHitlBridge(
+        coord,
+        workspace="wsp_li_test",
+        agent="agent:writer#v1",
+        reviewer="human:alice@example.org",
+    )
+
+
+def methods(bridge):
+    return [e["envelope"]["method"] for e in bridge.audit()]
+
+
+def last_params(bridge, method):
+    for entry in reversed(bridge.audit()):
+        if entry["envelope"]["method"] == method:
+            return entry["envelope"]["params"]
+    raise AssertionError(f"no {method} in audit")
+
+
+# ---- setup ---------------------------------------------------------
+
+
+def test_bridge_joins_agent_and_reviewer(coord, bridge):
+    ws = coord.workspaces["wsp_li_test"]
+    assert "agent:writer#v1" in ws.members
+    assert "human:alice@example.org" in ws.members
+
+
+def test_bridge_is_idempotent(coord, bridge):
+    ChapHitlBridge(coord, workspace="wsp_li_test",
+                   agent="agent:writer#v1", reviewer="human:alice@example.org")
+    assert len(coord.workspaces["wsp_li_test"].members) == 2
+
+
+# ---- the three decisions -------------------------------------------
+
+
+def test_approve(bridge):
+    seen = []
+    bridge.on_envelope = lambda m, p: seen.append(m)
+    bridge.record_decision(ask({"reply": "hi"}), reply(response="ok"), decision="approve")
+
+    assert seen == ["task.create", "task.complete", "review.request", "decide.approve"]
+    assert methods(bridge)[-1] == "decide.approve"
+
+
+def test_override_diffs_proposed_vs_returned(bridge):
+    bridge.record_decision(
+        ask({"amount": 100, "to": "acct-9"}),
+        reply(response={"amount": 50, "to": "acct-9"}, rationale="capped", tags=["limit"]),
+        decision="override",
+    )
+    params = last_params(bridge, "decide.override")
+    assert params["diff"] == [{"op": "replace", "path": "/amount", "value": 50}]
+    assert params["rationale"] == "capped"
+    assert params["tags"] == ["limit"]
+    assert params["intent_preserved"] is True
+
+
+def test_override_intent_preserved_from_response(bridge):
+    bridge.record_decision(
+        ask({"to": "acct-9"}),
+        reply(response={"to": "acct-escrow"}, intent_preserved=False),
+        decision="override",
+    )
+    assert last_params(bridge, "decide.override")["intent_preserved"] is False
+
+
+def test_override_with_no_change_is_an_approve(bridge):
+    bridge.record_decision(
+        ask({"amount": 100}), reply(response={"amount": 100}), decision="override",
+    )
+    assert methods(bridge)[-1] == "decide.approve"
+
+
+def test_reject_uses_response_as_note(bridge):
+    bridge.record_decision(
+        ask({"reply": "rude"}), reply(response="tone is off"), decision="reject",
+    )
+    assert last_params(bridge, "decide.reject")["comment"] == "tone is off"
+
+
+# ---- reading fields and overrides ----------------------------------
+
+
+def test_explicit_proposed_overrides_the_event(bridge):
+    bridge.record_decision(
+        ask({"ignored": True}), reply(response="ok"),
+        decision="approve", proposed={"real": "artefact"},
+    )
+    assert last_params(bridge, "review.request")["artefact"] == {"real": "artefact"}
+
+
+def test_per_decision_approver_from_response(coord, bridge):
+    bridge.record_decision(
+        ask({"x": 1}), reply(response="ok", user_name="service:autodeploy"),
+        decision="approve",
+    )
+    ws = coord.workspaces["wsp_li_test"]
+    assert ws.members["service:autodeploy"].type == "service"
+    assert last_params(bridge, "decide.approve")["from"] == "service:autodeploy"
+
+
+# ---- guards --------------------------------------------------------
+
+
+def test_unknown_decision_raises(bridge):
+    with pytest.raises(ValueError, match="approve"):
+        bridge.record_decision(ask({"x": 1}), reply(response="?"), decision="maybe")
+
+
+def test_chain_is_hash_linked(bridge):
+    bridge.record_decision(ask({"x": 1}), reply(response="ok"), decision="approve")
+    bridge.record_decision(ask({"x": 2}), reply(response="no"), decision="reject")
+    audit = bridge.audit()
+    assert len(audit) >= 8
+    assert all("prev_hash" in e for e in audit)
+
+
+def test_coordinator_error_surfaces(bridge):
+    with pytest.raises(ChapBridgeError):
+        bridge._dispatch("decide.approve", {
+            "workspace": bridge.workspace,
+            "from": bridge.reviewer,
+            "task_id": "tsk_does_not_exist",
+        })


### PR DESCRIPTION
Closes #1.

Adapter mirroring `chap-langgraph` / `chap-pydantic-ai`: when a LlamaIndex Workflow step pauses on an `InputRequiredEvent`, the human's `HumanResponseEvent` is recorded as a CHAP decision.

```
approve   -> decide.approve
override  -> decide.override   (proposed vs returned, as an RFC 6902 diff)
reject    -> decide.reject
```

**Design (per the plan on #1):**
- `decision` is explicit and authoritative — Workflows events are schemaless and carry no approve/edit/reject signal, so the adapter never infers intent. `proposed`/`returned`/`rationale`/`tags`/`intent_preserved`/`approver` default to `event.get(...)` with per-call overrides; arg names match the sibling bridges.
- Recorded from the **driver** (where both events meet), using the two-step `InputRequiredEvent` → `HumanResponseEvent` loop — so step replay never double-records.
- `llama-index-workflows` is optional; the bridge reads events structurally, so it and its tests run without it.
- **0.2.6-correct by construction**: approver joined, `review.request` addressed to that approver, so `from` is always a member and in the `to` set.

**Verified against `main` (0.2.6):** adapter `pytest` 12 passed; example runs on real `llama-index-workflows` 2.22 through approve / refining edit / substituting edit / reject; conformance harness 23/23.
