### PR TITLE
Adapter: record CHAP human-decision events from AG2 (AutoGen) human input

### DIFF
--- a/packages/chap-ag2/README.md
+++ b/packages/chap-ag2/README.md
@@ -1,0 +1,110 @@
+# chap-ag2
+
+Adapter between [AG2](https://github.com/ag2ai/ag2) (AutoGen) and the CHAP
+Coordinator. At an AG2 human-input turn, the human's decision -- approve,
+edit, or reject -- becomes a hash-linked, replayable CHAP audit entry.
+
+```
+decision      CHAP envelope
+--------      ---------------------------
+approve       decide.approve
+override      decide.override   (message vs reply, as a diff)
+reject        decide.reject
+```
+
+The agent message the human is responding to is the artefact under
+review; the human's reply is the decision on it.
+
+## Install
+
+```bash
+pip install chap-ag2
+```
+
+Depends on `chap-coordinator>=0.2.5`. AG2 is **optional**: the adapter
+reads the message and reply as plain values, so the bridge and its tests
+work without it installed. Install the extra to run a live conversation:
+
+```bash
+pip install "chap-ag2[ag2]"
+```
+
+## The decision is explicit
+
+AG2's human turn is a weak signal: the same `get_human_input` loop carries
+plain dialogue, edits, approvals, and "exit". Inferring intent would write
+decisions the human never made, which is the one thing this record exists
+to avoid. So `record_turn` takes the decision explicitly, and makes only
+one inference:
+
+- an **empty reply** means "use the agent's output" -> `decide.approve`
+- any **non-empty reply with no explicit decision** records **nothing** --
+  ending a chat is not a rejection, and dialogue is not an edit
+
+```python
+bridge.record_turn(message, reply, decision="override",
+                   rationale="over the limit", tags=["capped"])
+```
+
+`intent_preserved` defaults to `true` on an override; set it `false` for a
+substituting edit -- a different decision, not a refinement.
+
+## Where it hooks
+
+The message under review and the reply meet inside `get_human_input`, so
+that is where a turn is recorded. `self.last_message()` gives the message;
+the return value is the reply:
+
+```python
+from autogen import UserProxyAgent
+from chap_ag2 import ChapTurnBridge
+
+bridge = ChapTurnBridge(Coordinator(), workspace="wsp_support",
+                        agent="agent:assistant#v1", reviewer="human:alice@example.org")
+
+class RecordingUser(UserProxyAgent):
+    def get_human_input(self, prompt, **kw):
+        reply, decision = capture_from_ui(prompt)   # your UI supplies the intent
+        bridge.record_turn(self.last_message(), reply, decision=decision)
+        return reply
+```
+
+## Approver identity
+
+CHAP has no ambient actor: the decider is whatever `from` the envelope
+carries. The bridge uses its `reviewer` by default; pass a per-turn
+`approver` (a `human:` URI) to override it. The participant type is taken
+from the URI scheme and the approver is joined before recording. Each turn
+is its own task whose review is addressed to that approver, so the record
+satisfies the Coordinator's authorisation rules.
+
+## What you get in the audit chain
+
+One reviewed message with an edit yields:
+
+```
+seq=3  task.create     agent:assistant#v1
+seq=4  task.complete   agent:assistant#v1
+seq=5  review.request  agent:assistant#v1   to=human:sam@example.org
+seq=6  decide.override human:sam@example.org  diff=[{op:replace, path:, value:"refund $50 to Alice"}]
+```
+
+Every entry carries `prev_hash`, so the chain verifies externally or
+anchors to a SCITT transparency service with the `audit-scitt/1.0`
+profile.
+
+## Example
+
+`examples/01-approve-edit-reject.py` runs a real AG2 conversation (no LLM
+needed) through approve, an edit, and a reject, and prints the resulting
+chain.
+
+## Compatibility
+
+- `chap-coordinator` 0.2.6
+- `ag2` 0.9+ (optional; verified against 0.14)
+- Python 3.10, 3.11, 3.12, 3.13
+
+## License
+
+Apache 2.0. See [LICENSE](../../LICENSE).

--- a/packages/chap-ag2/chap_ag2/__init__.py
+++ b/packages/chap-ag2/chap_ag2/__init__.py
@@ -1,0 +1,273 @@
+"""
+chap-ag2: record a CHAP human-decision at an AG2 (AutoGen) human-input
+turn.
+
+AG2 collects human input through `get_human_input` on a UserProxyAgent /
+ConversableAgent running with `human_input_mode="ALWAYS"`. At that point
+the message under review is the agent's last message and the reply is the
+human's text. This adapter records that turn:
+
+    decision      CHAP envelope
+    --------      ---------------------------
+    approve       decide.approve
+    override      decide.override  (message vs reply, as a diff)
+    reject        decide.reject
+
+AG2's turn is a weak signal -- the same loop carries plain dialogue -- so
+`decision` is authoritative. The only inference the adapter makes is that
+an empty reply means "use the agent's output", i.e. approve. A non-empty
+reply with no explicit decision records nothing: ending a chat is not a
+rejection, and dialogue is not an edit.
+
+The bridge depends only on chap-coordinator. AG2 is never imported here:
+the message and reply are read structurally, so the same code runs
+against real AG2 objects or plain values.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+from chap_coordinator import Coordinator
+
+
+__version__ = "0.2.6"
+
+
+def _make_envelope(method: str, params: dict) -> dict:
+    return {
+        "jsonrpc": "2.0",
+        "id":      f"chap-ag2-{method}",
+        "method":  method,
+        "params":  params,
+    }
+
+
+def _content(message: Any) -> Any:
+    """The reviewable substance of an AG2 message: its content if the
+    message is a dict, else the message itself."""
+    if isinstance(message, dict):
+        return message.get("content", message)
+    return message
+
+
+def _is_empty(reply: Any) -> bool:
+    return not (reply or "").strip() if isinstance(reply, str) else not reply
+
+
+# ---- RFC 6902 diff (message -> reply, as a JSON Patch) ---------------
+
+
+def _escape(token: str) -> str:
+    return str(token).replace("~", "~0").replace("/", "~1")
+
+
+def _diff(before: Any, after: Any, path: str) -> list[dict]:
+    """Patch that turns `before` into `after`. Objects are walked
+    key-by-key; arrays and scalars are replaced whole. Keys are sorted so
+    the same edit always yields the same patch (it gets hashed into the
+    chain). Ported from the TypeScript coordinator's diffJsonPatch."""
+    if type(before) is not type(after) or not isinstance(before, dict):
+        return [] if before == after else [{"op": "replace", "path": path, "value": after}]
+    ops: list[dict] = []
+    for key in sorted(before.keys() | after.keys()):
+        at = f"{path}/{_escape(key)}"
+        if key not in after:
+            ops.append({"op": "remove", "path": at})
+        elif key not in before:
+            ops.append({"op": "add", "path": at, "value": after[key]})
+        else:
+            ops.extend(_diff(before[key], after[key], at))
+    return ops
+
+
+def _participant_type(uri: str) -> str:
+    scheme = uri.split(":", 1)[0]
+    return scheme if scheme in ("human", "agent", "service", "group") else "human"
+
+
+# ============================================================
+#   ChapTurnBridge
+# ============================================================
+
+
+@dataclass
+class ChapTurnBridge:
+    """One bridge per workspace. Holds the Coordinator, the workspace it
+    writes into, the agent whose message is under review, and the default
+    approver. Share it across a conversation; pass a per-turn approver when
+    the decision belongs to someone else.
+    """
+
+    coord:     Coordinator
+    workspace: str
+    agent:     str
+    reviewer:  str
+    profiles:  tuple = ("core/1.0", "review/1.0")
+    on_envelope: Optional[Callable[[str, dict], None]] = None
+
+    def __post_init__(self) -> None:
+        _safe_dispatch(self.coord, "workspace.create", {
+            "workspace": self.workspace,
+            "profiles":  list(self.profiles),
+        })
+        self._join(self.agent)
+        self._join(self.reviewer)
+
+    def record_turn(self, message: Any, reply: Any, *,
+                   decision: Optional[str] = None,
+                   approver: Optional[str] = None,
+                   rationale: Optional[str] = None,
+                   tags: Optional[list[str]] = None,
+                   intent_preserved: Optional[bool] = None) -> Optional[str]:
+        """Record one human turn and return the task id, or None if the
+        turn is not a decision.
+
+        `message` is the agent message the human responded to; `reply` is
+        their text. `decision` is authoritative. When it is omitted, only
+        an empty reply is inferred (approve); any other reply records
+        nothing, because AG2's loop also carries plain dialogue.
+        """
+        if decision is None:
+            if _is_empty(reply):
+                decision = "approve"
+            else:
+                return None
+
+        approver = approver or self.reviewer
+        if approver != self.reviewer:
+            self._join(approver)
+
+        proposed = _content(message)
+        task_id = self._submit(proposed, approver)
+
+        if decision == "approve":
+            self._decide("decide.approve", approver, task_id, rationale, tags)
+        elif decision == "override":
+            diff = _diff(proposed, reply, "")
+            if not diff:
+                self._decide("decide.approve", approver, task_id, rationale, tags)
+                return task_id
+            self._dispatch("decide.override", {
+                "workspace": self.workspace,
+                "from":      approver,
+                "task_id":   task_id,
+                "diff":      diff,
+                "rationale": rationale or "reviewer edited the message",
+                "tags":      tags or [],
+                "intent_preserved": True if intent_preserved is None else intent_preserved,
+            })
+        elif decision == "reject":
+            note = rationale or (reply if not _is_empty(reply) else None)
+            self._decide("decide.reject", approver, task_id, note, tags)
+        else:
+            raise ValueError(
+                f"decision must be 'approve', 'override', or 'reject': {decision!r}"
+            )
+        return task_id
+
+    def audit(self) -> list[dict]:
+        env = self._dispatch("audit.read", {"workspace": self.workspace})
+        return env["result"]["entries"]
+
+    # ---- internal -------------------------------------------------
+
+    def _submit(self, artefact: Any, approver: str) -> str:
+        """Record the message as the agent's task output and send it for
+        review -- the agent's half of the handshake."""
+        env = self._dispatch("task.create", {
+            "workspace": self.workspace,
+            "from":      self.agent,
+            "assignee":  self.agent,
+            "kind":      "agent_message",
+            "input":     artefact,
+        })
+        task_id = env["result"]["task_id"]
+        self._dispatch("task.complete", {
+            "workspace": self.workspace,
+            "from":      self.agent,
+            "task_id":   task_id,
+            "output":    artefact,
+        })
+        self._dispatch("review.request", {
+            "workspace": self.workspace,
+            "from":      self.agent,
+            "task_id":   task_id,
+            "artefact":  artefact,
+            "to":        approver,
+        })
+        return task_id
+
+    def _decide(self, method: str, approver: str, task_id: str,
+                comment: Optional[str], tags: Optional[list[str]]) -> None:
+        # decide.approve / decide.reject record the reviewer's note as
+        # `comment` (decide.override is the one that takes `rationale`).
+        params: dict = {
+            "workspace": self.workspace,
+            "from":      approver,
+            "task_id":   task_id,
+        }
+        if comment:
+            params["comment"] = comment
+        if tags:
+            params["tags"] = tags
+        self._dispatch(method, params)
+
+    def _join(self, uri: str) -> None:
+        _safe_dispatch(self.coord, "participant.join", {
+            "workspace": self.workspace,
+            "from":      uri,
+            "type":      _participant_type(uri),
+        })
+
+    def _dispatch(self, method: str, params: dict) -> dict:
+        if self.on_envelope is not None:
+            self.on_envelope(method, params)
+        out = self.coord.dispatch(_make_envelope(method, params))
+        if out.get("error"):
+            err = out["error"]
+            raise ChapBridgeError(err.get("code", 0), err.get("message", ""))
+        return out
+
+
+# ============================================================
+#   Errors and helpers
+# ============================================================
+
+
+class ChapBridgeError(RuntimeError):
+    """Raised when the Coordinator rejects an envelope."""
+
+    def __init__(self, code: int, message: str) -> None:
+        super().__init__(f"CHAP error {code}: {message}")
+        self.code = code
+        self.message = message
+
+
+def _safe_dispatch(coord: Coordinator, method: str, params: dict) -> None:
+    """Dispatch, tolerating the errors that come from re-applying an
+    idempotent setup step (re-creating a workspace, re-joining a member).
+    Decide by checking the resulting state, not by matching the message;
+    anything else propagates."""
+    out = coord.dispatch(_make_envelope(method, params))
+    if not out.get("error"):
+        return
+
+    if method == "workspace.create":
+        ws_id = params.get("workspace")
+        if ws_id and ws_id in coord.workspaces:
+            return
+    elif method == "participant.join":
+        ws = coord.workspaces.get(params.get("workspace"))
+        if ws is not None and params.get("from") in ws.members:
+            return
+
+    raise ChapBridgeError(out["error"].get("code", 0),
+                          out["error"].get("message", ""))
+
+
+__all__ = [
+    "ChapTurnBridge",
+    "ChapBridgeError",
+]

--- a/packages/chap-ag2/examples/01-approve-edit-reject.py
+++ b/packages/chap-ag2/examples/01-approve-edit-reject.py
@@ -1,0 +1,97 @@
+"""
+Example: approve, edit, and reject an AG2 (AutoGen) agent's messages at
+the human-input turn, and read the CHAP audit chain that results.
+
+Run (needs the optional AG2 extra):
+    pip install -e ".[ag2]"
+    python3 examples/01-approve-edit-reject.py
+
+The assistant runs without an LLM (a fixed draft). A UserProxyAgent
+records each human turn through the bridge from inside get_human_input,
+where both the message under review and the reply are available. The
+decision is scripted here, standing in for a UI that captures the human's
+intent -- AG2's reply text alone can't tell an edit from plain dialogue.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "coordinator-py"))
+
+from autogen import ConversableAgent, UserProxyAgent
+
+from chap_coordinator import Coordinator
+from chap_ag2 import ChapTurnBridge
+
+
+TURNS = [
+    {"reply": "", "decision": None},                     # empty -> approve
+    # Refining edit: same decision, smaller amount -> intent_preserved true.
+    {"reply": "refund $50 to Alice", "decision": "override",
+     "approver": "human:sam@example.org",
+     "rationale": "over the desk limit; capped to 50", "tags": ["limit-exceeded"]},
+    # Substituting edit: escalate instead of refunding, a different
+    # decision, so intent_preserved is false.
+    {"reply": "escalate to a supervisor instead of refunding", "decision": "override",
+     "approver": "human:sam@example.org",
+     "rationale": "not a refund call; escalating", "tags": ["substituted"],
+     "intent_preserved": False},
+    {"reply": "recipient is not on the allow-list", "decision": "reject"},
+    {"reply": "exit", "decision": None},                 # records nothing
+]
+
+
+def build_user(bridge: ChapTurnBridge) -> UserProxyAgent:
+    script = list(TURNS)
+
+    class RecordingUser(UserProxyAgent):
+        def get_human_input(self, prompt, **kw):
+            turn = script.pop(0) if script else {"reply": "exit", "decision": None}
+            bridge.record_turn(
+                self.last_message(), turn["reply"],
+                decision=turn.get("decision"),
+                approver=turn.get("approver"),
+                rationale=turn.get("rationale"),
+                tags=turn.get("tags"),
+                intent_preserved=turn.get("intent_preserved"),
+            )
+            return turn["reply"]
+
+    return RecordingUser("user", human_input_mode="ALWAYS",
+                         code_execution_config=False, default_auto_reply="")
+
+
+def main() -> None:
+    coord = Coordinator()
+    bridge = ChapTurnBridge(
+        coord,
+        workspace="wsp_support",
+        agent="agent:assistant#v1",
+        reviewer="human:alice@example.org",
+    )
+
+    assistant = ConversableAgent(
+        "assistant", llm_config=False,
+        default_auto_reply="Draft: refund $100 to Alice.",
+    )
+    user = build_user(bridge)
+    user.initiate_chat(assistant, message="please draft a refund", max_turns=6)
+
+    print("\nAudit chain")
+    print("===========")
+    for entry in bridge.audit():
+        env = entry["envelope"]
+        params = env.get("params", {})
+        who = params.get("from", "")
+        detail = ""
+        if env["method"] == "decide.override":
+            detail = (f"  intent_preserved={params['intent_preserved']}"
+                      f" diff={params['diff']} tags={params['tags']}")
+        elif env["method"] in ("decide.approve", "decide.reject"):
+            detail = f"  {params.get('comment', '')}"
+        print(f"  seq={entry['seq']:<2} {env['method']:<16} {who}{detail}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/chap-ag2/pyproject.toml
+++ b/packages/chap-ag2/pyproject.toml
@@ -1,0 +1,49 @@
+[build-system]
+requires      = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name            = "chap-ag2"
+version         = "0.2.6"
+description     = "CHAP adapter for AG2 (AutoGen): record a human-decision envelope at the human-input turn."
+readme          = "README.md"
+requires-python = ">=3.10"
+license         = { text = "Apache-2.0" }
+authors         = [ { name = "Brightbeam AI", email = "oss@brightbeam.ai" } ]
+keywords        = ["chap", "ag2", "autogen", "agent", "audit", "human-in-the-loop"]
+classifiers     = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries",
+]
+dependencies = [
+    "chap-coordinator>=0.2.5",
+]
+
+[project.optional-dependencies]
+# AG2 is only needed to run a live conversation. The adapter reads the
+# message and reply structurally, so the bridge and its tests work
+# without it installed.
+ag2 = ["ag2>=0.9"]
+dev = ["pytest>=8", "pytest-cov>=5"]
+
+[project.urls]
+Homepage      = "https://github.com/BrightbeamAI/chap"
+Repository    = "https://github.com/BrightbeamAI/chap"
+Specification = "https://github.com/BrightbeamAI/chap/blob/main/SPECIFICATION.md"
+
+[tool.setuptools.packages.find]
+include = ["chap_ag2*"]
+
+[tool.setuptools.package-data]
+"chap_ag2" = ["py.typed"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/packages/chap-ag2/tests/test_bridge.py
+++ b/packages/chap-ag2/tests/test_bridge.py
@@ -1,0 +1,162 @@
+"""
+Tests for chap-ag2. They run without AG2 installed: the bridge reads the
+message and reply as plain values, so a dict message and a string reply
+stand in for a real AG2 turn.
+
+    1. An agent message under review -> task.create + complete + review.request.
+    2. A human turn -> decide.approve | decide.override | decide.reject
+       (or nothing, for plain dialogue).
+    3. The audit chain carries the whole trail, hash-linked.
+"""
+
+import sys
+from pathlib import Path
+
+THIS = Path(__file__).resolve()
+sys.path.insert(0, str(THIS.parents[1]))
+sys.path.insert(0, str(THIS.parents[2] / "coordinator-py"))
+
+import pytest
+
+from chap_coordinator import Coordinator, CoordinatorOptions
+from chap_ag2 import ChapTurnBridge, ChapBridgeError
+
+
+def msg(content, name="assistant"):
+    return {"content": content, "role": "user", "name": name}
+
+
+@pytest.fixture
+def coord():
+    return Coordinator(CoordinatorOptions(
+        deterministic_ids=True, deterministic_clock=True, enable_chain=True,
+    ))
+
+
+@pytest.fixture
+def bridge(coord):
+    return ChapTurnBridge(
+        coord,
+        workspace="wsp_ag2_test",
+        agent="agent:assistant#v1",
+        reviewer="human:alice@example.org",
+    )
+
+
+def methods(bridge):
+    return [e["envelope"]["method"] for e in bridge.audit()]
+
+
+def last_params(bridge, method):
+    for entry in reversed(bridge.audit()):
+        if entry["envelope"]["method"] == method:
+            return entry["envelope"]["params"]
+    raise AssertionError(f"no {method} in audit")
+
+
+# ---- setup ---------------------------------------------------------
+
+
+def test_bridge_joins_agent_and_reviewer(coord, bridge):
+    ws = coord.workspaces["wsp_ag2_test"]
+    assert "agent:assistant#v1" in ws.members
+    assert "human:alice@example.org" in ws.members
+
+
+# ---- the safe fallback: only empty -> approve ----------------------
+
+
+def test_empty_reply_infers_approve(bridge):
+    tid = bridge.record_turn(msg("draft"), "")
+    assert tid is not None
+    assert methods(bridge)[-1] == "decide.approve"
+
+
+def test_non_empty_reply_without_decision_records_nothing(bridge):
+    tid = bridge.record_turn(msg("draft"), "what about the tax?")
+    assert tid is None
+    assert methods(bridge) == ["workspace.create", "participant.join", "participant.join"]
+
+
+def test_exit_is_not_a_reject(bridge):
+    tid = bridge.record_turn(msg("draft"), "exit")
+    assert tid is None
+    assert "decide.reject" not in methods(bridge)
+
+
+# ---- explicit decisions --------------------------------------------
+
+
+def test_explicit_approve(bridge):
+    seen = []
+    bridge.on_envelope = lambda m, p: seen.append(m)
+    bridge.record_turn(msg("draft"), "", decision="approve")
+    assert seen == ["task.create", "task.complete", "review.request", "decide.approve"]
+
+
+def test_override_diffs_message_vs_reply(bridge):
+    bridge.record_turn(
+        msg("refund $100 to Alice"), "refund $50 to Alice",
+        decision="override", rationale="over the limit", tags=["capped"],
+    )
+    params = last_params(bridge, "decide.override")
+    assert params["diff"] == [{"op": "replace", "path": "", "value": "refund $50 to Alice"}]
+    assert params["rationale"] == "over the limit"
+    assert params["intent_preserved"] is True
+
+
+def test_override_intent_preserved_false(bridge):
+    bridge.record_turn(msg("ship it"), "hold the release",
+                       decision="override", intent_preserved=False)
+    assert last_params(bridge, "decide.override")["intent_preserved"] is False
+
+
+def test_override_with_no_change_is_an_approve(bridge):
+    bridge.record_turn(msg("keep as is"), "keep as is", decision="override")
+    assert methods(bridge)[-1] == "decide.approve"
+
+
+def test_explicit_reject_uses_reply_as_note(bridge):
+    bridge.record_turn(msg("rude draft"), "tone is unacceptable", decision="reject")
+    assert last_params(bridge, "decide.reject")["comment"] == "tone is unacceptable"
+
+
+# ---- artefact and identity -----------------------------------------
+
+
+def test_message_content_is_the_artefact(bridge):
+    bridge.record_turn(msg("the draft body"), "", decision="approve")
+    assert last_params(bridge, "review.request")["artefact"] == "the draft body"
+
+
+def test_per_turn_approver_from_uri_scheme(coord, bridge):
+    bridge.record_turn(msg("draft"), "", decision="approve",
+                       approver="service:autodeploy")
+    ws = coord.workspaces["wsp_ag2_test"]
+    assert ws.members["service:autodeploy"].type == "service"
+    assert last_params(bridge, "decide.approve")["from"] == "service:autodeploy"
+
+
+# ---- guards --------------------------------------------------------
+
+
+def test_unknown_decision_raises(bridge):
+    with pytest.raises(ValueError, match="approve"):
+        bridge.record_turn(msg("draft"), "x", decision="maybe")
+
+
+def test_chain_is_hash_linked(bridge):
+    bridge.record_turn(msg("a"), "", decision="approve")
+    bridge.record_turn(msg("b"), "no good", decision="reject")
+    audit = bridge.audit()
+    assert len(audit) >= 8
+    assert all("prev_hash" in e for e in audit)
+
+
+def test_coordinator_error_surfaces(bridge):
+    with pytest.raises(ChapBridgeError):
+        bridge._dispatch("decide.approve", {
+            "workspace": bridge.workspace,
+            "from": bridge.reviewer,
+            "task_id": "tsk_does_not_exist",
+        })


### PR DESCRIPTION
Closes #3.

Adapter mirroring `chap-langgraph` / the other two: at an AG2 human-input turn, the human's decision is recorded as a CHAP envelope.

```
approve   -> decide.approve
override  -> decide.override   (message vs reply, as a diff)
reject    -> decide.reject
```

**Design, per your corrections on #3:**
- `decision` is explicit and authoritative. The only inference is `empty reply → approve`; any non-empty reply with no explicit decision **records nothing** — `"exit"` is not a reject, and dialogue is not an edit.
- `intent_preserved` defaults `true` on override, overridable; no-op edit → approve.
- Hooked at `get_human_input`, where both the message (`self.last_message()`) and the reply are available — not the prompt string. Verified `last_message()` returns the message under review at that point.
- `ag2` is optional; the bridge reads the message/reply structurally, so it and its tests run without it.
- **0.2.6-correct by construction**: approver joined, `review.request` addressed to them.

**Verified against `main` (0.2.6):** `pytest` 14 passed; example runs a real AG2 conversation (no LLM) through approve / edit / reject, with `exit` recording nothing; conformance harness 23/23.
