### PR TITLE
Scenario 3: the indie founder, the inbox, and the angry customer

### DIFF
--- a/scenarios/03-founder-inbox/README.md
+++ b/scenarios/03-founder-inbox/README.md
@@ -1,0 +1,94 @@
+# Scenario 3: the indie founder, the inbox, and the angry customer
+
+> Narrative: [`IN_PRACTICE.md` §3](../../IN_PRACTICE.md#3-the-indie-founder-the-inbox-and-the-angry-customer)
+> · Profiles: `core/1.0`, `review/1.0`, `audit-scitt/1.0` · No framework · **good first issue**
+
+## The story
+
+A solo SaaS founder puts a triage agent in front of the support inbox: it
+drafts a reply, and the founder approves, edits, or escalates each one. Six
+weeks in, a customer files a chargeback claiming the bot quoted the wrong
+refund policy. The provider logs have expired and the keys have rotated, so
+the founder's own memory is the only record — except every ticket ran
+through a CHAP coordinator.
+
+One `audit.read` reconstructs the disputed ticket's whole history in order.
+A scan of the same chain then shows the bigger problem: the founder approved
+the *same wrong policy* on seven earlier tickets, not just this one. Fix the
+agent's retrieval, and the next ticket is correct. Six months later a
+contractor onboards by reading the chain, not the founder's mind.
+
+## Run it
+
+```bash
+python3 scenario.py
+```
+
+That is the whole setup. The script has **no dependencies beyond the
+standard library**: from a clone of the repo it imports the in-repo
+`coordinator-py` automatically, and once `chap-coordinator` is on PyPI,
+`pip install chap-coordinator` works with the same script. No network, no
+services, no config.
+
+## What you'll see
+
+1. **Is this record trustworthy?** It re-walks the hash chain the way an
+   auditor would (recomputing `sha256(JCS(envelope) || prev_hash)` for
+   every entry), confirms it is intact, then shows that quietly
+   reattributing one past approval on a copy breaks verification at that
+   entry. When the chargeback lands, the record is provable, not a story
+   about expired logs.
+2. **The chargeback query.** It pulls the disputed ticket back out of the
+   chain and prints its full history in order — opened, drafted, sent for
+   review, approved — and shows the one ticket the founder escalated, which
+   opened a new task for a specialist rather than ending there.
+3. **The pattern scan.** It counts how many drafts cited the wrong refund
+   policy across the whole chain. The punchline: not one bad ticket but
+   seven, so the fix is the agent's retrieval, not this one reply.
+
+### Output shape
+
+```
+2. The chargeback: reconstruct ticket 8821 from the chain
+   task.create      ticket opened, drafted by the triage agent
+   task.update      agent drafting
+   task.complete    draft cites refund-30d
+   review.request   sent to the founder
+   decide.approve   approved by human:you@saas.com
+   (separately, ticket 8822 was escalated -> new task tsk_... for human:specialist@saas.com)
+
+3. Pattern scan: which tickets cited the wrong policy?
+   Drafts citing 'refund-30d' (the wrong policy): 7
+   Tickets: 8815, 8816, 8817, 8818, 8819, 8820, 8821
+```
+
+The sample set is small so the run is instant; the point is the pattern,
+not the volume.
+
+## A note on `policy_cited`
+
+The wrong policy the bot quoted lives as `policy_cited` on the draft
+artefact — deliberately **not** the protocol's `policy_refs`. `policy_refs`
+is the *governing* policy of a task or decision; `policy_cited` is *content*
+the agent wrote into its draft, and the whole scenario turns on that content
+being wrong. Modelling it as artefact content is what lets the pattern scan
+count it.
+
+## CHAP methods used
+
+| Method | Role in the story |
+|---|---|
+| `workspace.create` | Open the workspace with `core/1.0` + `review/1.0` + `audit-scitt/1.0` (the last adds the hash-linked chain). |
+| `participant.join` | Join the founder (`human:you@saas.com`), the triage agent (`agent:triage@saas.com`), and the specialist (`human:specialist@saas.com`). |
+| `task.create` | Open a `support_reply` task for a ticket, assigned to the triage agent. |
+| `task.update` | The agent reports `in_progress`. |
+| `task.complete` | The agent records its draft reply (with the cited policy) as the task's output artefact. |
+| `review.request` | The agent asks the founder to review, addressed `to` the founder. |
+| `decide.approve` / `decide.override` | The founder approves or edits the draft; overrides carry `diff`, `rationale`. |
+| `escalate.raise` | The founder hands a hard ticket up: the original task becomes `escalated` and a new task opens for the specialist. |
+| `audit.read` | Reconstruct one ticket's history, and scan every draft for the wrong policy. |
+
+Note the authorisation shape every scenario respects: the founder is joined
+before they decide, and the review is addressed to the founder who then
+decides it. A decision from a non-member, or from a member who was not an
+addressed reviewer, is refused (`-32011`).

--- a/scenarios/03-founder-inbox/scenario.py
+++ b/scenarios/03-founder-inbox/scenario.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""
+Scenario 3: the indie founder, the inbox, and the angry customer.
+
+IN_PRACTICE.md S3. A solo SaaS founder puts a triage agent (an ``agent:``
+participant here) in front of the support inbox: it drafts a reply, and the
+founder approves, edits, or escalates each one. Six weeks in a customer
+files a chargeback claiming the bot quoted the wrong refund policy. The
+provider logs have expired and the keys have rotated, but every ticket ran
+through a CHAP coordinator, so one query reconstructs the whole story, and a
+scan of the same chain shows the founder approved the same wrong policy on
+seven earlier tickets.
+
+This uses CHAP core plus two profiles that ship with the reference
+coordinator (review/1.0, audit-scitt/1.0). No framework, no network, and no
+dependencies beyond the standard library.
+
+Run it:
+
+    # from a clone of the repo, nothing to install:
+    python3 scenario.py
+
+    # or, once chap-coordinator is on PyPI:
+    pip install chap-coordinator && python3 scenario.py
+
+It prints three things, in order:
+  1. a check that the audit chain is intact, and that a tamper would be
+     caught;
+  2. the chargeback query: one ticket's full history, reconstructed in
+     order from the chain (draft -> decision -> outbound), plus the ticket
+     that was escalated into a new task;
+  3. the pattern scan: the seven earlier tickets where the bot cited the
+     same wrong policy, the moment the founder fixes retrieval.
+"""
+from __future__ import annotations
+
+import copy
+import sys
+from pathlib import Path
+
+# Import the coordinator. Prefer an installed chap-coordinator; fall back to
+# the in-repo package so a fresh clone runs with nothing installed.
+try:
+    from chap_coordinator import Coordinator, CoordinatorOptions
+    from chap_coordinator.canonical import canonicalize, sha256_hex
+except ModuleNotFoundError:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "packages" / "coordinator-py"))
+    from chap_coordinator import Coordinator, CoordinatorOptions
+    from chap_coordinator.canonical import canonicalize, sha256_hex
+
+
+WORKSPACE = "wsp_support"
+FOUNDER = "human:you@saas.com"        # approves, edits, or escalates; the reviewer
+TRIAGE = "agent:triage@saas.com"      # drafts the first reply to each ticket
+SPECIALIST = "human:specialist@saas.com"  # takes the tickets the founder escalates
+PROFILES = ["core/1.0", "review/1.0", "audit-scitt/1.0"]
+GENESIS = "sha256:" + "0" * 64
+
+WRONG_POLICY = "refund-30d"   # what the bot's retrieval kept quoting
+RIGHT_POLICY = "refund-14d"   # the actual policy, once retrieval is fixed
+CHARGEBACK = "8821"           # the ticket the customer disputes
+
+
+def _draft(ticket: str, reply: str, policy: str) -> dict:
+    # policy_cited is content the bot put in its draft, deliberately kept
+    # distinct from the protocol's policy_refs (the governing policy of a
+    # task): the whole point of the scenario is that this citation is wrong.
+    return {"ticket": ticket, "reply": reply, "policy_cited": policy}
+
+
+def main() -> None:
+    coord = Coordinator(CoordinatorOptions(
+        deterministic_ids=True,     # stable output across runs
+        deterministic_clock=True,
+        default_profiles=PROFILES,
+    ))
+
+    def send(method: str, **params) -> dict:
+        resp = coord.dispatch({
+            "jsonrpc": "2.0", "id": method, "method": method, "params": params,
+        })
+        if "error" in resp:
+            raise SystemExit(f"{method} failed: {resp['error']}")
+        return resp["result"]
+
+    ctx = build_history(send)
+
+    entries = send("audit.read", workspace=WORKSPACE)["entries"]
+    print_integrity(entries)
+    print_reconstruction(send, ctx)
+    print_pattern_scan(send)
+
+
+# ---------------------------------------------------------------------------
+# Six weeks of tickets: mostly approved, a couple edited, one escalated.
+# Seven of them quote the wrong refund policy before retrieval is fixed.
+# ---------------------------------------------------------------------------
+
+# (ticket, decision, policy, note, diff). The chargeback ticket and six others
+# carry the wrong policy; one ticket is escalated; the last, after the fix,
+# quotes the right one.
+TICKETS = [
+    ("8815", "approve",  WRONG_POLICY, "Standard refund question; looked fine.", None),
+    ("8816", "approve",  WRONG_POLICY, "Refund window question; approved.", None),
+    ("8817", "override", WRONG_POLICY, "Softened the tone before sending.",
+     [{"op": "replace", "path": "/reply",
+       "value": "Sorry for the hassle -- here's how refunds work."}]),
+    ("8818", "approve",  WRONG_POLICY, "Another refund query; approved.", None),
+    ("8819", "approve",  WRONG_POLICY, "Refund timing; approved.", None),
+    ("8820", "override", WRONG_POLICY, "Added the account link.",
+     [{"op": "replace", "path": "/reply",
+       "value": "You can request a refund from your account settings."}]),
+    (CHARGEBACK, "approve", WRONG_POLICY,
+     "Refund declined per policy; approved and sent.", None),
+    ("8822", "escalate", "billing-dispute",
+     "Duplicate charge across two plans -- beyond a template reply.", None),
+    ("8830", "approve",  RIGHT_POLICY,
+     "Retrieval fixed; the draft now cites the real policy.", None),
+]
+
+
+def build_history(send) -> dict:
+    send("workspace.create", workspace=WORKSPACE, profiles=PROFILES)
+    for uri, type_, role in (
+        (FOUNDER, "human", "reviewer"),
+        (TRIAGE, "agent", "drafter"),
+        (SPECIALIST, "human", "specialist"),
+    ):
+        send("participant.join", workspace=WORKSPACE, **{"from": uri},
+             type=type_, role=role)
+
+    ticket_to_task: dict = {}
+    escalation: dict = {}
+
+    for ticket, decision, policy, note, diff in TICKETS:
+        created = send("task.create", workspace=WORKSPACE, **{"from": FOUNDER},
+                       kind="support_reply", assignee=TRIAGE, input={"ticket": ticket})
+        task_id = created["task_id"]
+        ticket_to_task[ticket] = task_id
+        send("task.update", workspace=WORKSPACE, **{"from": TRIAGE},
+             task_id=task_id, state="in_progress")
+
+        artefact = _draft(ticket, f"Reply for ticket {ticket}.", policy)
+        send("task.complete", workspace=WORKSPACE, **{"from": TRIAGE},
+             task_id=task_id, output=artefact)
+        send("review.request", workspace=WORKSPACE, **{"from": TRIAGE},
+             task_id=task_id, to=[FOUNDER], artefact=artefact)
+
+        if decision == "approve":
+            send("decide.approve", workspace=WORKSPACE, **{"from": FOUNDER},
+                 task_id=task_id, comment=note)
+        elif decision == "override":
+            send("decide.override", workspace=WORKSPACE, **{"from": FOUNDER},
+                 task_id=task_id, diff=diff, rationale=note, intent_preserved=True)
+        else:  # escalate: hands the ticket up, opening a new task for the specialist
+            result = send("escalate.raise", workspace=WORKSPACE, **{"from": FOUNDER},
+                          original_task_id=task_id,
+                          new_task={"assignee": SPECIALIST, "kind": "support_reply",
+                                    "input": {"ticket": ticket, "reason": note}})
+            escalation = {"ticket": ticket, "from_task": task_id,
+                          "new_task": result["new_task_id"]}
+
+    return {"ticket_to_task": ticket_to_task, "escalation": escalation}
+
+
+# ---------------------------------------------------------------------------
+# 1. Integrity: the chain is hash-linked, so it is tamper-evident.
+# ---------------------------------------------------------------------------
+
+def _verify(entries):
+    """Re-walk the hash chain the way an auditor would. Each entry carries the
+    prev_hash it was linked against; the next link is
+    sha256(JCS(envelope) || prev_hash). If any envelope was altered after the
+    fact, the recomputed links stop matching."""
+    running = GENESIS
+    for e in entries:
+        if e.get("prev_hash") != running:
+            return False, e["seq"]
+        running = sha256_hex(canonicalize(e["envelope"]) + running.encode("utf-8"))
+    return True, None
+
+
+def print_integrity(entries) -> None:
+    print("1. Is this record trustworthy?")
+    print("=" * 52)
+    intact, _ = _verify(entries)
+    print(f"   Audit entries on the chain: {len(entries)}")
+    print(f"   Chain verifies (hash-linked, intact): {intact}")
+
+    forged = copy.deepcopy(entries)
+    for e in forged:
+        if e["envelope"]["method"] == "decide.approve":
+            e["envelope"]["params"]["from"] = "human:not-you@saas.com"
+            break
+    intact_after, broken_seq = _verify(forged)
+    print(f"   If one approval were quietly reattributed: verifies = {intact_after}"
+          f" (breaks at seq {broken_seq})")
+    print("   -> when the chargeback lands, the draft, your decision, and the")
+    print("      outbound are provable, not a story about expired logs.")
+    print()
+
+
+# ---------------------------------------------------------------------------
+# 2. The chargeback query: one ticket's full history, in order.
+# ---------------------------------------------------------------------------
+
+def print_reconstruction(send, ctx) -> None:
+    task_id = ctx["ticket_to_task"][CHARGEBACK]
+    # Select every entry for this ticket. task.create carries the ticket in
+    # its input (not a task_id, which the coordinator only returns in the
+    # result), so match it separately; everything else carries task_id.
+    story = []
+    for e in send("audit.read", workspace=WORKSPACE)["entries"]:
+        p = e["envelope"].get("params", {})
+        if p.get("task_id") == task_id or (
+            e["envelope"]["method"] == "task.create"
+            and (p.get("input") or {}).get("ticket") == CHARGEBACK
+        ):
+            story.append(e)
+
+    print(f"2. The chargeback: reconstruct ticket {CHARGEBACK} from the chain")
+    print("=" * 52)
+    for e in story:
+        env = e["envelope"]
+        p = env.get("params", {})
+        detail = {
+            "task.create":    "ticket opened, drafted by the triage agent",
+            "task.update":    "agent drafting",
+            "task.complete":  f"draft cites {(p.get('output') or {}).get('policy_cited')}",
+            "review.request": "sent to the founder",
+            "decide.approve": f"approved by {p.get('from')}",
+        }.get(env["method"], "")
+        print(f"   {env['method']:<16} {detail}")
+    esc = ctx["escalation"]
+    print(f"   (separately, ticket {esc['ticket']} was escalated -> new task"
+          f" {esc['new_task']} for {SPECIALIST})")
+    print("   -> the whole story in order, months after the provider logs expired.")
+    print()
+
+
+# ---------------------------------------------------------------------------
+# 3. The pattern scan: how many tickets quoted the same wrong policy.
+# ---------------------------------------------------------------------------
+
+def print_pattern_scan(send) -> None:
+    completed = send("audit.read", workspace=WORKSPACE,
+                     filter={"method": "task.complete"})["entries"]
+    wrong = []
+    for e in completed:
+        out = e["envelope"]["params"].get("output") or {}
+        if out.get("policy_cited") == WRONG_POLICY:
+            wrong.append(out["ticket"])
+
+    print("3. Pattern scan: which tickets cited the wrong policy?")
+    print("=" * 52)
+    print(f"   Drafts citing '{WRONG_POLICY}' (the wrong policy): {len(wrong)}")
+    print(f"   Tickets: {', '.join(wrong)}")
+    print(f"   -> not one bad ticket but {len(wrong)}. You fix the agent's")
+    print("      retrieval to consult the real policy; the next ticket cites")
+    print(f"      '{RIGHT_POLICY}' and is correct.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #12.

Scenario 3 (the indie founder, the inbox, and the angry customer) as a runnable `scenarios/03-founder-inbox/`, mirroring the worked `scenarios/01-solo-dev-overrides/`: a zero-dependency `scenario.py` + a `README.md`.

Core + `review/1.0` + `audit-scitt/1.0`, standard library only, deterministic. A triage agent drafts `support_reply` artefacts, the founder approves / edits / escalates, and seven early tickets carry the same wrong refund policy. Three beats: chain integrity (and a caught tamper), the `audit.read` reconstruction of the chargeback ticket's full history in order, and a scan that surfaces the seven wrong-policy drafts.

Both refinements from the issue thread:
- `escalate.raise` shows its **continuation** — the escalated ticket opens a new task for the specialist, not a terminal state.
- the wrongly-quoted policy is `policy_cited`, modelled as **artefact content** and kept distinct from the protocol's `policy_refs` (the governing policy); the pattern scan counts it.

Verified against current `main` (0.2.6): runs clean and deterministically, the chain verifies and a forged approval breaks it, the reconstruction shows the full ticket history plus the escalation's new task, and the scan lands 7 tickets on `refund-30d`. Authorisation shape respected.

Follow-up (separate PR): a `live/` layer adapting `reference/playground` (triage inbox, real human approve/edit/escalate, the chain and wrong-policy scan in the UI), model optional via `CHAP_NO_LLM` so CI falls back to this deterministic path.
