### PR TITLE
Adapter: record CHAP human-decision events from Google ADK tool confirmations

### DIFF
--- a/packages/chap-google-adk/README.md
+++ b/packages/chap-google-adk/README.md
@@ -1,0 +1,114 @@
+# chap-google-adk
+
+Adapter between [Google ADK](https://google.github.io/adk-docs/) and the
+CHAP Coordinator. When an ADK run pauses for tool confirmation, the human's
+decision -- approve, edit, or reject -- becomes a hash-linked, replayable
+CHAP audit entry.
+
+```
+decision      CHAP envelope
+--------      ---------------------------
+approve       decide.approve
+override      decide.override   (original args vs the edited value)
+reject        decide.reject
+```
+
+The paused tool call (name + args) is the artefact under review; the
+`ToolConfirmation` the human returns is the decision on it. An edit is
+recorded as an RFC 6902 diff, so the chain captures *what changed and why*,
+not just *approved/denied*.
+
+## Install
+
+```bash
+pip install chap-google-adk
+```
+
+Depends on `chap-coordinator>=0.2.5`. Google ADK is **optional**: the adapter
+reads the call and confirmation structurally, so the bridge and its tests
+work without it installed. Install the extra to run a live agent:
+
+```bash
+pip install "chap-google-adk[google-adk]"
+```
+
+## Quick start
+
+ADK gates a tool with `FunctionTool(fn, require_confirmation=True)` (or a
+tool calling `tool_context.request_confirmation(...)`). The run pauses and
+surfaces the paused call plus a `ToolConfirmation`; you resume by returning
+a `ToolConfirmation`. Record the decision at that resolution point:
+
+```python
+from google.adk.tools.tool_confirmation import ToolConfirmation
+from chap_coordinator import Coordinator
+from chap_google_adk import ChapConfirmationBridge
+
+bridge = ChapConfirmationBridge(
+    Coordinator(),
+    workspace="wsp_payments",
+    agent="agent:assistant#v1",
+    reviewer="human:alice@example.org",
+)
+
+# `tool_call` is the paused call (its .name / .args); `confirmation` is the
+# ToolConfirmation the human returned.
+bridge.record_decision(tool_call, confirmation)                    # confirmed -> approve
+bridge.record_decision(tool_call, confirmation, decision="reject")  # or not confirmed
+bridge.record_decision(                                             # an edit
+    tool_call, confirmation,
+    decision="override", returned={"amount": 50, "to": "acct-9"},
+    approver="human:sam@example.org", rationale="over the desk limit",
+)
+```
+
+## approve/reject derived, override explicit
+
+`confirmation.confirmed` is a clean approve/reject signal, so those two are
+derived from it (an explicit `decision` still wins). An **override is never
+inferred**: ADK's `payload` is a separate, tool-defined object (a leave tool
+asks for `approved_days`, not a modified `days`), so treating it as the
+edited args would record a change the human never made. An edit is recorded
+only when you pass it explicitly — the edited args as `returned`, or a
+ready-made RFC 6902 `diff`. `intent_preserved` defaults to `true` on an
+override; set it `false` for a substituting edit. A no-op edit records
+`decide.approve`.
+
+## Approver identity
+
+CHAP has no ambient actor: the decider is whatever `from` the envelope
+carries. The bridge uses its `reviewer` by default; pass a per-decision
+`approver` (a `human:` URI) to override it. The participant type is taken
+from the URI scheme and the approver is joined before recording. Each
+decision is its own task whose review is addressed to that approver, so the
+record satisfies the Coordinator's authorisation rules.
+
+## What you get in the audit chain
+
+One confirmed-with-an-edit call yields:
+
+```
+seq=3  task.create     agent:assistant#v1
+seq=4  task.complete   agent:assistant#v1
+seq=5  review.request  agent:assistant#v1   to=human:sam@example.org
+seq=6  decide.override human:sam@example.org  diff=[{op:replace, path:/args/amount, value:50}]
+```
+
+Every entry carries `prev_hash`, so the chain verifies externally or anchors
+to a SCITT transparency service with the `audit-scitt/1.0` profile.
+
+## Example
+
+`examples/01-approve-edit-reject.py` drives one confirmation-gated tool
+through approve, a refining edit, a substituting edit, and a reject against
+real `google-adk` (offline, no API key), and prints the resulting chain.
+
+## Compatibility
+
+- `chap-coordinator` 0.2.6
+- `google-adk` >=1.29 (optional; tool-confirmation API present since 1.29, example verified on 2.3)
+- Python 3.10, 3.11, 3.12, 3.13
+
+## License
+
+Apache 2.0. See [LICENSE](../../LICENSE).

--- a/packages/chap-google-adk/chap_google_adk/__init__.py
+++ b/packages/chap-google-adk/chap_google_adk/__init__.py
@@ -1,0 +1,293 @@
+"""
+chap-google-adk: record a CHAP human-decision when a Google ADK run pauses
+for tool confirmation.
+
+ADK gates a tool with ``FunctionTool(fn, require_confirmation=True)`` (or a
+tool calling ``tool_context.request_confirmation(...)``). The run pauses and
+surfaces the paused call plus a ``ToolConfirmation``; the app resumes by
+returning a ``ToolConfirmation(confirmed=..., payload=...)``. This adapter
+records the decision at that resolution point:
+
+    decision      CHAP envelope
+    --------      ---------------------------
+    approve       decide.approve
+    override      decide.override  (original args vs the edited value)
+    reject        decide.reject
+
+The confirmation's ``confirmed`` flag is a clean approve/reject signal, so
+approve/reject are derived from it. Override is never inferred: ADK's
+``payload`` is a separate, tool-defined object (a leave tool asks for
+``approved_days``, not a modified ``days``), so treating it as the edited
+args would record a change the human never made. An edit is recorded only
+when the caller passes it explicitly via ``returned`` (the edited args) or
+``diff``.
+
+The bridge depends only on chap-coordinator. google-adk is never imported
+here: the call and confirmation are read structurally, so the same code runs
+against real ADK objects or plain values.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+from chap_coordinator import Coordinator
+
+
+__version__ = "0.2.6"
+
+
+def _make_envelope(method: str, params: dict) -> dict:
+    return {
+        "jsonrpc": "2.0",
+        "id":      f"chap-google-adk-{method}",
+        "method":  method,
+        "params":  params,
+    }
+
+
+# ---- reading ADK objects without importing them ----------------------
+
+
+def _attr(obj: Any, key: str, default: Any = None) -> Any:
+    """Read a field whether ``obj`` is an ADK model (attribute) or a plain
+    dict (the shape ADK also serialises confirmations into)."""
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _args(tool_call: Any) -> dict:
+    args = _attr(tool_call, "args")
+    return dict(args) if args else {}
+
+
+def _confirmed(confirmation: Any) -> bool:
+    return bool(_attr(confirmation, "confirmed", False))
+
+
+# ---- RFC 6902 diff (original args -> edited args, as a JSON Patch) ----
+
+
+def _escape(token: str) -> str:
+    return str(token).replace("~", "~0").replace("/", "~1")
+
+
+def _diff(before: Any, after: Any, path: str) -> list[dict]:
+    """Patch that turns `before` into `after`. Objects are walked
+    key-by-key; arrays and scalars are replaced whole. Keys are sorted so
+    the same edit always yields the same patch (it gets hashed into the
+    chain). Ported from the TypeScript coordinator's diffJsonPatch."""
+    if type(before) is not type(after) or not isinstance(before, dict):
+        return [] if before == after else [{"op": "replace", "path": path, "value": after}]
+    ops: list[dict] = []
+    for key in sorted(before.keys() | after.keys()):
+        at = f"{path}/{_escape(key)}"
+        if key not in after:
+            ops.append({"op": "remove", "path": at})
+        elif key not in before:
+            ops.append({"op": "add", "path": at, "value": after[key]})
+        else:
+            ops.extend(_diff(before[key], after[key], at))
+    return ops
+
+
+def _participant_type(uri: str) -> str:
+    scheme = uri.split(":", 1)[0]
+    return scheme if scheme in ("human", "agent", "service", "group") else "human"
+
+
+# ============================================================
+#   ChapConfirmationBridge
+# ============================================================
+
+
+@dataclass
+class ChapConfirmationBridge:
+    """One bridge per workspace. Holds the Coordinator, the workspace it
+    writes into, the agent whose tool call is under review, and the default
+    approver. Share it across a run; pass a per-decision approver when the
+    decision belongs to someone else.
+    """
+
+    coord:     Coordinator
+    workspace: str
+    agent:     str
+    reviewer:  str
+    profiles:  tuple = ("core/1.0", "review/1.0")
+    on_envelope: Optional[Callable[[str, dict], None]] = None
+
+    def __post_init__(self) -> None:
+        _safe_dispatch(self.coord, "workspace.create", {
+            "workspace": self.workspace,
+            "profiles":  list(self.profiles),
+        })
+        self._join(self.agent)
+        self._join(self.reviewer)
+
+    def record_decision(self, tool_call: Any, confirmation: Any, *,
+                        decision: Optional[str] = None,
+                        returned: Optional[dict] = None,
+                        diff: Optional[list[dict]] = None,
+                        approver: Optional[str] = None,
+                        rationale: Optional[str] = None,
+                        tags: Optional[list[str]] = None,
+                        intent_preserved: Optional[bool] = None) -> str:
+        """Record one resolved confirmation and return the task id.
+
+        `tool_call` is the paused call (its name + args are the artefact);
+        `confirmation` is the ToolConfirmation the human returned. `decision`
+        defaults to approve/reject read from `confirmed`; an override is
+        never inferred and must be passed explicitly with the edited args
+        (`returned`) or a `diff`.
+        """
+        approver = approver or self.reviewer
+        if approver != self.reviewer:
+            self._join(approver)
+
+        args = _args(tool_call)
+        artefact = {
+            "tool":         _attr(tool_call, "name"),
+            "args":         args,
+            "tool_call_id": _attr(tool_call, "id"),
+        }
+        if decision is None:
+            decision = "approve" if _confirmed(confirmation) else "reject"
+
+        task_id = self._submit(artefact, approver)
+
+        if decision == "approve":
+            self._decide("decide.approve", approver, task_id, rationale, tags)
+        elif decision == "override":
+            if diff is None:
+                if returned is None:
+                    raise ValueError(
+                        "an override needs `returned` (the edited args) or a `diff`"
+                    )
+                diff = _diff(args, returned, "/args")
+            if not diff:
+                # The edit changed nothing; record the approve it really is.
+                self._decide("decide.approve", approver, task_id, rationale, tags)
+                return task_id
+            self._dispatch("decide.override", {
+                "workspace": self.workspace,
+                "from":      approver,
+                "task_id":   task_id,
+                "diff":      diff,
+                "rationale": rationale or "reviewer edited the tool arguments",
+                "tags":      tags or [],
+                "intent_preserved": True if intent_preserved is None else intent_preserved,
+            })
+        elif decision == "reject":
+            self._decide("decide.reject", approver, task_id, rationale, tags)
+        else:
+            raise ValueError(
+                f"decision must be 'approve', 'override', or 'reject': {decision!r}"
+            )
+        return task_id
+
+    def audit(self) -> list[dict]:
+        env = self._dispatch("audit.read", {"workspace": self.workspace})
+        return env["result"]["entries"]
+
+    # ---- internal -------------------------------------------------
+
+    def _submit(self, artefact: dict, approver: str) -> str:
+        """Record the tool call as the agent's task output and send it for
+        review -- the agent's half of the handshake."""
+        env = self._dispatch("task.create", {
+            "workspace": self.workspace,
+            "from":      self.agent,
+            "assignee":  self.agent,
+            "kind":      artefact["tool"] or "tool_call",
+            "input":     artefact,
+        })
+        task_id = env["result"]["task_id"]
+        self._dispatch("task.complete", {
+            "workspace": self.workspace,
+            "from":      self.agent,
+            "task_id":   task_id,
+            "output":    artefact,
+        })
+        self._dispatch("review.request", {
+            "workspace": self.workspace,
+            "from":      self.agent,
+            "task_id":   task_id,
+            "artefact":  artefact,
+            "to":        approver,
+        })
+        return task_id
+
+    def _decide(self, method: str, approver: str, task_id: str,
+                comment: Optional[str], tags: Optional[list[str]]) -> None:
+        # decide.approve / decide.reject record the reviewer's note as
+        # `comment` (decide.override is the one that takes `rationale`).
+        params: dict = {
+            "workspace": self.workspace,
+            "from":      approver,
+            "task_id":   task_id,
+        }
+        if comment:
+            params["comment"] = comment
+        if tags:
+            params["tags"] = tags
+        self._dispatch(method, params)
+
+    def _join(self, uri: str) -> None:
+        _safe_dispatch(self.coord, "participant.join", {
+            "workspace": self.workspace,
+            "from":      uri,
+            "type":      _participant_type(uri),
+        })
+
+    def _dispatch(self, method: str, params: dict) -> dict:
+        if self.on_envelope is not None:
+            self.on_envelope(method, params)
+        out = self.coord.dispatch(_make_envelope(method, params))
+        if out.get("error"):
+            err = out["error"]
+            raise ChapBridgeError(err.get("code", 0), err.get("message", ""))
+        return out
+
+
+# ============================================================
+#   Errors and helpers
+# ============================================================
+
+
+class ChapBridgeError(RuntimeError):
+    """Raised when the Coordinator rejects an envelope."""
+
+    def __init__(self, code: int, message: str) -> None:
+        super().__init__(f"CHAP error {code}: {message}")
+        self.code = code
+        self.message = message
+
+
+def _safe_dispatch(coord: Coordinator, method: str, params: dict) -> None:
+    """Dispatch, tolerating the errors that come from re-applying an
+    idempotent setup step (re-creating a workspace, re-joining a member).
+    Decide by checking the resulting state, not by matching the message;
+    anything else propagates."""
+    out = coord.dispatch(_make_envelope(method, params))
+    if not out.get("error"):
+        return
+
+    if method == "workspace.create":
+        ws_id = params.get("workspace")
+        if ws_id and ws_id in coord.workspaces:
+            return
+    elif method == "participant.join":
+        ws = coord.workspaces.get(params.get("workspace"))
+        if ws is not None and params.get("from") in ws.members:
+            return
+
+    raise ChapBridgeError(out["error"].get("code", 0),
+                          out["error"].get("message", ""))
+
+
+__all__ = [
+    "ChapConfirmationBridge",
+    "ChapBridgeError",
+]

--- a/packages/chap-google-adk/examples/01-approve-edit-reject.py
+++ b/packages/chap-google-adk/examples/01-approve-edit-reject.py
@@ -1,0 +1,138 @@
+"""
+Example: approve, edit, and reject one confirmation-gated Google ADK tool,
+and read the CHAP audit chain that results.
+
+Run (needs the optional ADK extra):
+    pip install -e ".[google-adk]"
+    python3 examples/01-approve-edit-reject.py
+
+It drives ADK with a scripted model, so it runs offline with no API key.
+The model proposes a `transfer` call; the run pauses for confirmation, the
+bridge records the human's decision, and a `ToolConfirmation` resumes the
+run -- as decide.approve / decide.override / decide.reject.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "coordinator-py"))
+
+from google.genai import types
+from google.adk.agents import LlmAgent
+from google.adk.models import BaseLlm, LlmResponse
+from google.adk.runners import Runner
+from google.adk.sessions import InMemorySessionService
+from google.adk.tools import FunctionTool
+from google.adk.tools.tool_confirmation import ToolConfirmation
+
+from chap_coordinator import Coordinator
+from chap_google_adk import ChapConfirmationBridge
+
+CONFIRM = "adk_request_confirmation"
+ORIGINAL = {"amount": 100, "to": "Alice"}
+
+
+def transfer(amount: int, to: str) -> str:
+    return f"sent {amount} to {to}"
+
+
+class ScriptedLlm(BaseLlm):
+    """Proposes the transfer on the first turn, then a closing line."""
+
+    calls: int = 0
+
+    async def generate_content_async(self, llm_request, stream=False):
+        self.calls += 1
+        if self.calls == 1:
+            yield LlmResponse(content=types.Content(role="model", parts=[
+                types.Part(function_call=types.FunctionCall(
+                    name="transfer", args=dict(ORIGINAL)))]))
+        else:
+            yield LlmResponse(content=types.Content(
+                role="model", parts=[types.Part(text="done")]))
+
+
+def _new_runner() -> Runner:
+    agent = LlmAgent(name="pay", model=ScriptedLlm(model="scripted"),
+                     tools=[FunctionTool(transfer, require_confirmation=True)])
+    return Runner(app_name="pay", agent=agent,
+                  session_service=InMemorySessionService())
+
+
+async def _pause(runner, sid):
+    """Run until the confirmation pause; return the request-confirmation call."""
+    await runner.session_service.create_session(
+        app_name="pay", user_id="u", session_id=sid)
+    msg = types.Content(role="user", parts=[types.Part(text="pay Alice 100")])
+    async for event in runner.run_async(user_id="u", session_id=sid, new_message=msg):
+        lr = getattr(event, "long_running_tool_ids", None) or set()
+        for part in (event.content.parts if event.content else []):
+            fc = part.function_call
+            if fc and fc.name == CONFIRM and fc.id in lr:
+                return fc
+    raise RuntimeError("no confirmation request")
+
+
+async def _resume(runner, sid, conf_id, confirmed):
+    resp = {"confirmed": confirmed}
+    msg = types.Content(role="user", parts=[types.Part(
+        function_response=types.FunctionResponse(
+            id=conf_id, name=CONFIRM, response=resp))])
+    async for _ in runner.run_async(user_id="u", session_id=sid, new_message=msg):
+        pass
+
+
+async def decide(bridge, sid, *, confirmed, decision=None, **kw):
+    runner = _new_runner()
+    conf_fc = await _pause(runner, sid)
+    tool_call = conf_fc.args["originalFunctionCall"]      # {name, args, id}
+    bridge.record_decision(
+        tool_call, ToolConfirmation(confirmed=confirmed),
+        decision=decision, **kw)
+    await _resume(runner, sid, conf_fc.id, confirmed)
+
+
+async def main() -> None:
+    coord = Coordinator()
+    bridge = ChapConfirmationBridge(
+        coord, workspace="wsp_payments",
+        agent="agent:assistant#v1", reviewer="human:alice@example.org")
+
+    # Approve as proposed (decision derived from confirmed=True).
+    await decide(bridge, "s1", confirmed=True)
+
+    # Refining edit: cap the amount, same decision -> intent_preserved true.
+    await decide(bridge, "s2", confirmed=True, decision="override",
+                 returned={**ORIGINAL, "amount": 50},
+                 approver="human:sam@example.org",
+                 rationale="over the desk limit; capped to 50", tags=["limit-exceeded"])
+
+    # Substituting edit: redirect the payment, a different decision.
+    await decide(bridge, "s3", confirmed=True, decision="override",
+                 returned={**ORIGINAL, "to": "Escrow"},
+                 approver="human:sam@example.org",
+                 rationale="wrong recipient; routed to escrow", tags=["wrong-recipient"],
+                 intent_preserved=False)
+
+    # Reject (decision derived from confirmed=False).
+    await decide(bridge, "s4", confirmed=False, rationale="recipient not allow-listed")
+
+    print("Audit chain")
+    print("===========")
+    for entry in bridge.audit():
+        env = entry["envelope"]
+        params = env.get("params", {})
+        who = params.get("from", "")
+        detail = ""
+        if env["method"] == "decide.override":
+            detail = (f"  intent_preserved={params['intent_preserved']}"
+                      f" diff={params['diff']} tags={params['tags']}")
+        elif env["method"] in ("decide.approve", "decide.reject"):
+            detail = f"  {params.get('comment', '')}"
+        print(f"  seq={entry['seq']:<2} {env['method']:<16} {who}{detail}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/chap-google-adk/pyproject.toml
+++ b/packages/chap-google-adk/pyproject.toml
@@ -1,0 +1,49 @@
+[build-system]
+requires      = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name            = "chap-google-adk"
+version         = "0.2.6"
+description     = "CHAP adapter for Google ADK: record a human-decision envelope when a run pauses for tool confirmation."
+readme          = "README.md"
+requires-python = ">=3.10"
+license         = { text = "Apache-2.0" }
+authors         = [ { name = "Brightbeam AI", email = "oss@brightbeam.ai" } ]
+keywords        = ["chap", "google-adk", "adk", "agent", "audit", "human-in-the-loop", "tool-confirmation"]
+classifiers     = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries",
+]
+dependencies = [
+    "chap-coordinator>=0.2.5",
+]
+
+[project.optional-dependencies]
+# Google ADK is only needed to run a live agent. The adapter reads the call
+# and confirmation structurally, so the bridge and its tests work without it
+# installed.
+google-adk = ["google-adk>=1.29"]
+dev        = ["pytest>=8", "pytest-cov>=5"]
+
+[project.urls]
+Homepage      = "https://github.com/BrightbeamAI/chap"
+Repository    = "https://github.com/BrightbeamAI/chap"
+Specification = "https://github.com/BrightbeamAI/chap/blob/main/SPECIFICATION.md"
+
+[tool.setuptools.packages.find]
+include = ["chap_google_adk*"]
+
+[tool.setuptools.package-data]
+"chap_google_adk" = ["py.typed"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/packages/chap-google-adk/tests/test_bridge.py
+++ b/packages/chap-google-adk/tests/test_bridge.py
@@ -1,0 +1,191 @@
+"""
+Tests for chap-google-adk. They run without google-adk installed: the bridge
+reads the call and confirmation structurally, so small stand-ins (and plain
+dicts) drive the same code path the real ADK objects would.
+
+    1. A paused tool call under review -> task.create + complete + review.request.
+    2. A resolved confirmation -> decide.approve | decide.override | decide.reject.
+    3. The audit chain carries the whole trail, hash-linked.
+"""
+
+import sys
+from pathlib import Path
+
+THIS = Path(__file__).resolve()
+sys.path.insert(0, str(THIS.parents[1]))
+sys.path.insert(0, str(THIS.parents[2] / "coordinator-py"))
+
+import pytest
+
+from chap_coordinator import Coordinator, CoordinatorOptions
+from chap_google_adk import ChapConfirmationBridge, ChapBridgeError
+
+
+class Call:
+    """A paused FunctionCall stand-in (attribute access, like the real one)."""
+
+    def __init__(self, name, args, id="fc-1"):
+        self.name = name
+        self.args = args
+        self.id = id
+
+
+class Conf:
+    """A ToolConfirmation stand-in."""
+
+    def __init__(self, confirmed, payload=None):
+        self.confirmed = confirmed
+        self.payload = payload
+
+
+@pytest.fixture
+def coord():
+    return Coordinator(CoordinatorOptions(
+        deterministic_ids=True, deterministic_clock=True, enable_chain=True,
+    ))
+
+
+@pytest.fixture
+def bridge(coord):
+    return ChapConfirmationBridge(
+        coord,
+        workspace="wsp_adk_test",
+        agent="agent:assistant#v1",
+        reviewer="human:alice@example.org",
+    )
+
+
+def methods(bridge):
+    return [e["envelope"]["method"] for e in bridge.audit()]
+
+
+def last_params(bridge, method):
+    for entry in reversed(bridge.audit()):
+        if entry["envelope"]["method"] == method:
+            return entry["envelope"]["params"]
+    raise AssertionError(f"no {method} in audit")
+
+
+# ---- setup ---------------------------------------------------------
+
+
+def test_bridge_joins_agent_and_reviewer(coord, bridge):
+    ws = coord.workspaces["wsp_adk_test"]
+    assert "agent:assistant#v1" in ws.members
+    assert "human:alice@example.org" in ws.members
+
+
+# ---- approve / reject derived from `confirmed` ---------------------
+
+
+def test_confirmed_is_approve(bridge):
+    seen = []
+    bridge.on_envelope = lambda m, p: seen.append(m)
+    bridge.record_decision(Call("transfer", {"amount": 100}), Conf(True))
+    assert seen == ["task.create", "task.complete", "review.request", "decide.approve"]
+
+
+def test_not_confirmed_is_reject(bridge):
+    bridge.record_decision(Call("transfer", {"amount": 100}), Conf(False))
+    assert methods(bridge)[-1] == "decide.reject"
+
+
+def test_explicit_decision_overrides_the_flag(bridge):
+    # confirmed=True, but the caller says reject -> reject wins.
+    bridge.record_decision(Call("transfer", {"amount": 100}), Conf(True),
+                           decision="reject", rationale="not this recipient")
+    assert methods(bridge)[-1] == "decide.reject"
+
+
+# ---- override is explicit, never inferred from payload -------------
+
+
+def test_confirmed_with_payload_is_still_approve(bridge):
+    # A payload is tool-defined data, not the edited args. It must NOT be
+    # promoted to an override.
+    bridge.record_decision(Call("book_leave", {"days": 5}),
+                           Conf(True, payload={"approved_days": 3}))
+    assert methods(bridge)[-1] == "decide.approve"
+
+
+def test_override_uses_returned_not_payload(bridge):
+    bridge.record_decision(
+        Call("transfer", {"amount": 100, "to": "acct-9"}),
+        Conf(True, payload={"anything": "tool-defined"}),
+        decision="override", returned={"amount": 50, "to": "acct-9"},
+        rationale="capped", tags=["limit"],
+    )
+    params = last_params(bridge, "decide.override")
+    assert params["diff"] == [{"op": "replace", "path": "/args/amount", "value": 50}]
+    assert params["intent_preserved"] is True
+
+
+def test_override_intent_preserved_false(bridge):
+    bridge.record_decision(
+        Call("transfer", {"to": "acct-9"}), Conf(True),
+        decision="override", returned={"to": "acct-escrow"}, intent_preserved=False,
+    )
+    assert last_params(bridge, "decide.override")["intent_preserved"] is False
+
+
+def test_override_without_edit_raises(bridge):
+    with pytest.raises(ValueError, match="edited args"):
+        bridge.record_decision(Call("transfer", {"amount": 100}), Conf(True),
+                               decision="override")
+
+
+def test_override_with_no_change_is_an_approve(bridge):
+    bridge.record_decision(
+        Call("transfer", {"amount": 100}), Conf(True),
+        decision="override", returned={"amount": 100},
+    )
+    assert methods(bridge)[-1] == "decide.approve"
+
+
+# ---- structural reads ----------------------------------------------
+
+
+def test_dict_shaped_call_and_confirmation(bridge):
+    bridge.record_decision({"name": "ship", "args": {"env": "prod"}, "id": "fc-9"},
+                           {"confirmed": False})
+    assert "decide.reject" in methods(bridge)
+    assert last_params(bridge, "review.request")["artefact"]["tool"] == "ship"
+
+
+def test_artefact_is_the_tool_call(bridge):
+    bridge.record_decision(Call("send_email", {"to": "x@y.z"}), Conf(True))
+    art = last_params(bridge, "review.request")["artefact"]
+    assert art == {"tool": "send_email", "args": {"to": "x@y.z"}, "tool_call_id": "fc-1"}
+
+
+def test_per_decision_approver_type_from_uri(coord, bridge):
+    bridge.record_decision(Call("ship", {"env": "prod"}), Conf(True),
+                           approver="service:autodeploy")
+    ws = coord.workspaces["wsp_adk_test"]
+    assert ws.members["service:autodeploy"].type == "service"
+    assert last_params(bridge, "decide.approve")["from"] == "service:autodeploy"
+
+
+# ---- guards --------------------------------------------------------
+
+
+def test_unknown_decision_raises(bridge):
+    with pytest.raises(ValueError, match="approve"):
+        bridge.record_decision(Call("x", {}), Conf(True), decision="maybe")
+
+
+def test_chain_is_hash_linked(bridge):
+    bridge.record_decision(Call("a", {}), Conf(True))
+    bridge.record_decision(Call("b", {}), Conf(False))
+    audit = bridge.audit()
+    assert len(audit) >= 8
+    assert all("prev_hash" in e for e in audit)
+
+
+def test_coordinator_error_surfaces(bridge):
+    with pytest.raises(ChapBridgeError):
+        bridge._dispatch("decide.approve", {
+            "workspace": bridge.workspace,
+            "from": bridge.reviewer,
+            "task_id": "tsk_does_not_exist",
+        })


### PR DESCRIPTION
Closes #8.

Adapter mirroring the merged `chap-pydantic-ai`: when an ADK run pauses on a `require_confirmation` tool, the human's `ToolConfirmation` is recorded as a CHAP decision.

```
approve   -> decide.approve
override  -> decide.override   (original args vs the edit, as an RFC 6902 diff)
reject    -> decide.reject
```

**Per your correction on the issue:** approve/reject are derived from `confirmed` (explicit `decision` still wins); an **override is never inferred from `payload`** — since ADK's payload is a separate tool-defined object, the edit is passed explicitly via `returned=`/`diff=`, never defaulted from payload. No-op edit → approve. `google-adk` optional; call/confirmation read structurally so tests run without it. 0.2.6-correct by construction (approver joined, `review.request` addressed to that approver).

The `google-adk` extra floor is `>=1.29`, determined empirically (the tool-confirmation API is present from 1.29 through 2.3), not guessed.

**Verified against `main` (0.2.6):** `pytest` 15 passed; the example drives a real `google-adk` confirmation flow offline (scripted model, no API key) through approve / refining edit / substituting edit / reject; conformance harness 23/23.
