### PR TITLE
Reject uncanonicalisable envelopes before the handler runs

### DIFF
--- a/packages/coordinator-py/chap_coordinator/coordinator.py
+++ b/packages/coordinator-py/chap_coordinator/coordinator.py
@@ -418,6 +418,11 @@ class Coordinator:
             )
 
         try:
+            canonicalize(envelope)
+        except (ValueError, TypeError) as exc:
+            return make_response(env_id, error=rpc_error(E.PARAMS, str(exc)))
+
+        try:
             out = handler(params)
         except Exception as exc:
             # Keep the wire message generic; a handler exception may carry

--- a/packages/coordinator/src/coordinator.ts
+++ b/packages/coordinator/src/coordinator.ts
@@ -463,6 +463,13 @@ export class Coordinator {
       return reply(envelope, { error: rpcError(E.METHOD, `Unknown method: ${method}`) });
     }
 
+    try {
+      canonicalize(envelope);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return reply(envelope, { error: rpcError(E.PARAMS, msg) });
+    }
+
     let out: { result?: unknown; error?: { code: number; message: string; data?: unknown } };
     try {
       out = handler(params);


### PR DESCRIPTION
`dispatch()` could raise instead of returning a JSON-RPC error. `_record_audit`
canonicalises the envelope after the handler has mutated state and outside the
try/except, so a value it cannot canonicalise left the operation applied but
never recorded; on an unchained workspace it was stored instead and broke every
later chain replay.

Now checked in `dispatch` after the existing gates: the envelope is refused with
`-32602` and nothing is committed.

Coordinator suite 174/174, adapter suites 69/69.

Closes #20
