### PR TITLE
Do not report an unchained workspace as tampered

### DIFF
--- a/packages/coordinator-py/chap_coordinator/profiles/audit_scitt.py
+++ b/packages/coordinator-py/chap_coordinator/profiles/audit_scitt.py
@@ -143,9 +143,13 @@ def register_audit_scitt(coord: "Coordinator") -> None:
         ws = coord.workspaces.get(p.get("workspace", ""))
         if not ws:
             return {"error": rpc_error(E.PARAMS, "Unknown workspace")}
+        if not (ws.chain_enabled or coord.options.enable_chain):
+            return {"error": rpc_error(E.PARAMS, "Chain not enabled for this workspace")}
+        start = next((i for i, e in enumerate(ws.audit) if e.prev_hash is not None),
+                     len(ws.audit))
         errors: list[str] = []
         prev = ZERO_HASH
-        for e in ws.audit:
+        for e in ws.audit[start:]:
             expected_prev = prev
             # A chain-enabled workspace must have prev_hash on every entry;
             # a missing value is a defect, not a reason to skip the check.
@@ -161,7 +165,7 @@ def register_audit_scitt(coord: "Coordinator") -> None:
             return {"error": rpc_error(E.PARAMS, "; ".join(errors))}
         return {"result": {
             "ok": True,
-            "entries_checked": len(ws.audit),
+            "entries_checked": len(ws.audit) - start,
             "chain_head": stored_head,
         }}
 

--- a/packages/coordinator/src/profiles/audit_scitt.ts
+++ b/packages/coordinator/src/profiles/audit_scitt.ts
@@ -85,9 +85,14 @@ export function registerAuditScitt(coord: Coordinator): void {
   coord.handlers.set("audit.verify_chain", (p) => {
     const ws = coord.workspaces.get(p.workspace as string);
     if (!ws) return { error: rpcError(E.PARAMS, "Unknown workspace") };
+    if (!(ws.chain_enabled || coord.options.enableChain)) {
+      return { error: rpcError(E.PARAMS, "Chain not enabled for this workspace") };
+    }
+    let start = ws.audit.findIndex(e => e.prev_hash != null);
+    if (start < 0) start = ws.audit.length;
     const errors: string[] = [];
     let prev = ZERO_HASH;
-    for (const e of ws.audit) {
+    for (const e of ws.audit.slice(start)) {
       const expectedPrev = prev;
       // A chain-enabled workspace must have prev_hash on every entry; a
       // missing value is a defect, not a reason to skip the check.
@@ -107,7 +112,7 @@ export function registerAuditScitt(coord: Coordinator): void {
     }
     return { result: {
       ok: true,
-      entries_checked: ws.audit.length,
+      entries_checked: ws.audit.length - start,
       chain_head: storedHead,
     }};
   });


### PR DESCRIPTION
`verify_chain` compared every entry's `prev_hash` against the replayed hash, but
entries recorded before the chain was enabled legitimately have none, so a clean
log came back as a mismatch on every entry. `set_profiles` can also enable the
chain mid-life, which restarts it at `ZERO_HASH` and leaves earlier entries
unchained.

Refuses the call when no chain exists, and replays from the first chained entry.
A missing `prev_hash` inside the chained run is still a mismatch, so the opt-out
closed in 0.2.7 stays closed — `test_tamper_last_entry_with_dropped_prev_hash_caught`
still passes.

Coordinator suite 174/174, adapter suites 69/69.

Closes #22
