### PR TITLE
Do not replace an existing member on participant.join

### DIFF
--- a/packages/coordinator-py/chap_coordinator/coordinator.py
+++ b/packages/coordinator-py/chap_coordinator/coordinator.py
@@ -763,6 +763,8 @@ class Coordinator:
                     jwk=vp_jwk, kid=vp_jwk["kid"], valid_from=now,
                 ))
 
+        attested = list(member.keys)
+
         # security-signed/1.0: register any JWKs supplied in the join envelope.
         jwks = p.get("jwks")
         if isinstance(jwks, dict):
@@ -774,6 +776,16 @@ class Coordinator:
                             jwk=j, kid=j["kid"], valid_from=now,
                         ))
 
+        existing = ws.members.get(uri)
+        if existing is not None:
+            for f in ("oidc_sub", "oidc_auth_time", "vc_holder"):
+                v = getattr(member, f)
+                if v is not None:
+                    setattr(existing, f, v)
+            for k in attested:
+                if not any(x.kid == k.kid for x in existing.keys):
+                    existing.keys.append(k)
+            return {"result": {"joined": True, "as": uri}}
         ws.members[uri] = member
         return {"result": {"joined": True, "as": uri}}
 

--- a/packages/coordinator/src/coordinator.ts
+++ b/packages/coordinator/src/coordinator.ts
@@ -754,6 +754,8 @@ export class Coordinator {
       }
     }
 
+    const attested = [...member.keys];
+
     // security-signed/1.0: register supplied JWKs
     const jwks = p.jwks as { keys?: Array<{ kid: string; [k: string]: unknown }> } | undefined;
     if (jwks?.keys) {
@@ -764,6 +766,16 @@ export class Coordinator {
       }
     }
 
+    const existing = ws.members.get(uri);
+    if (existing) {
+      if (member.oidc_sub !== undefined) existing.oidc_sub = member.oidc_sub;
+      if (member.oidc_auth_time !== undefined) existing.oidc_auth_time = member.oidc_auth_time;
+      if (member.vc_holder !== undefined) existing.vc_holder = member.vc_holder;
+      for (const k of attested) {
+        if (!existing.keys.some(x => x.kid === k.kid)) existing.keys.push(k);
+      }
+      return { result: { joined: true, as: uri } };
+    }
     ws.members.set(uri, member);
     return { result: { joined: true, as: uri } };
   }


### PR DESCRIPTION
A re-join built a fresh `Member` and overwrote the stored one, so `role`,
`scopes`, `display_name` and registered keys were all reset from the join
envelope. Consequences on 0.2.7:

- a revoked key came back **un-revoked**, undoing revocation
- `role` reviewer -> participant, `scopes` `['approve']` -> `None`
- with `require_signatures=True`, a caller registered their own key against
  `human:alice` and envelopes they signed then verified as alice
  (`participant.join` is signature-exempt)

A re-join now refreshes only the verified identity binding
(`oidc_sub`/`oidc_auth_time`/`vc_holder`) and adds only keys an identity
verifier attested (`cnf.jwk`, `vp_jwk`). Self-asserted `jwks` is not accepted
for an already-admitted URI, per SPECIFICATION.md:1409. New members are
unaffected — joining with `jwks` still registers them normally.

Two narrower fixes were tried first and rejected, in case they look obvious:

- insert-only (rejecting the re-join) permanently locks out step-up, because
  `oidc_auth_time` is set only in this handler and nowhere else
- never touching an existing member leaves participants joined without keys
  permanently keyless, since `rotate_key` requires an existing `old_kid`

Applied to both reference implementations. Python suite 174/174, adapters
69/69, TypeScript 122/122.

Closes #24
