### PR TITLE
Fail closed when no SCITT receipt verifier is configured

### DIFF
--- a/packages/coordinator-py/chap_coordinator/coordinator.py
+++ b/packages/coordinator-py/chap_coordinator/coordinator.py
@@ -56,6 +56,7 @@ AuditListener = Callable[[str, AuditEntry], None]
 TokenVerifier = Callable[[str], dict | None]
 CredentialVerifier = Callable[[dict], dict | None]
 ScittSubmitter = Callable[[dict], dict | None]  # SCITT statement -> receipt or None
+ScittReceiptVerifier = Callable[[dict], bool]  # receipt -> verified?
 
 
 # Methods classified as privileged for step-up auth (identity-oidc/1.0 S4
@@ -102,6 +103,10 @@ class CoordinatorOptions:
     scitt_submitter: ScittSubmitter | None = None
     """Hook for audit-scitt/1.0; called with a SCITT signed statement;
     returns the receipt (opaque to CHAP) or None on failure."""
+
+    verify_scitt_receipt: ScittReceiptVerifier | None = None
+    """Hook for audit-scitt/1.0; called with a receipt; returns whether it
+    verifies. When unset, audit.verify_receipt fails closed."""
 
     routing_policy: Callable[[Task, list[str]], dict] | None = None
     """Hook for routing/1.0 task.route; returns {selected, rationale...}."""

--- a/packages/coordinator-py/chap_coordinator/profiles/audit_scitt.py
+++ b/packages/coordinator-py/chap_coordinator/profiles/audit_scitt.py
@@ -128,8 +128,9 @@ def register_audit_scitt(coord: "Coordinator") -> None:
                 return {"error": rpc_error(E.SCITT_RECEIPT_INVALID,
                                            "Receipt did not verify")}
             return {"result": {"verified": True}}
-        return {"result": {"verified": None,
-                           "note": "No verify_scitt_receipt hook configured"}}
+        return {"error": rpc_error(
+            E.SCITT_RECEIPT_INVALID,
+            "No verify_scitt_receipt hook configured; receipt not verified")}
 
     def audit_verify_chain(p: dict) -> dict:
         """Local prev_hash chain replay (supplementary to SCITT).

--- a/packages/coordinator/src/profiles/audit_scitt.ts
+++ b/packages/coordinator/src/profiles/audit_scitt.ts
@@ -79,7 +79,7 @@ export function registerAuditScitt(coord: Coordinator): void {
       if (!ok) return { error: rpcError(E.SCITT_RECEIPT_INVALID, "Receipt did not verify") };
       return { result: { verified: true } };
     }
-    return { result: { verified: null, note: "No verifyScittReceipt hook configured" } };
+    return { error: rpcError(E.SCITT_RECEIPT_INVALID, "No verifyScittReceipt hook configured; receipt not verified") };
   });
 
   coord.handlers.set("audit.verify_chain", (p) => {


### PR DESCRIPTION
`audit.verify_receipt` returned `{verified: null}` as a success result when no
verifier hook was set, so a caller checking only for a JSON-RPC error treated
an unverified (or forged) receipt as valid. It now returns an error.

The Python `CoordinatorOptions` was also missing the `verify_scitt_receipt`
hook the handler reads, so the verifier path was unreachable and
`verify_receipt` could never succeed; this adds it, matching the TypeScript
`verifyScittReceipt` option.

Applied to both reference implementations. Python suite 174/174, adapters
69/69, TypeScript 122/122; TS typecheck and schema check clean.

Closes #26
