### PR TITLE
Add regression tests for the 0.2.7 dispatch and join fixes

### DIFF
--- a/packages/coordinator-py/tests/test_ingress_canonicalisation.py
+++ b/packages/coordinator-py/tests/test_ingress_canonicalisation.py
@@ -1,0 +1,58 @@
+"""
+Regression: dispatch must reject an envelope it cannot canonicalise instead of
+letting a handler run and then raising while linking the audit chain. A
+non-integer or unsafe-integer number is refused with PARAMS, before any state
+changes. Guards the 0.2.7 fix.
+"""
+from __future__ import annotations
+
+from chap_coordinator import Coordinator, CoordinatorOptions
+from chap_coordinator.jsonrpc import E
+
+
+def _ready(**opts):
+    c = Coordinator(CoordinatorOptions(deterministic_ids=True, **opts))
+
+    def s(method, **params):
+        return c.dispatch({"jsonrpc": "2.0", "id": method, "method": method, "params": params})
+
+    s("workspace.create", workspace="w")
+    s("participant.join", workspace="w", **{"from": "human:a"}, type="human")
+    s("participant.join", workspace="w", **{"from": "agent:b"}, type="agent")
+    r = s("task.create", workspace="w", **{"from": "human:a"},
+          kind="k", input={}, assignee="agent:b")
+    tid = r["result"]["task_id"]
+    s("task.update", workspace="w", **{"from": "agent:b"}, task_id=tid, state="in_progress")
+    return c, s, tid
+
+
+def test_non_integer_number_is_rejected_with_params():
+    c, s, tid = _ready()
+    r = s("task.complete", workspace="w", **{"from": "agent:b"},
+          task_id=tid, output={}, confidence=0.86)
+    assert "error" in r
+    assert r["error"]["code"] == E.PARAMS
+
+
+def test_unsafe_integer_is_rejected_with_params():
+    c, s, tid = _ready()
+    r = s("task.complete", workspace="w", **{"from": "agent:b"},
+          task_id=tid, output={}, confidence=2 ** 53)
+    assert "error" in r
+    assert r["error"]["code"] == E.PARAMS
+
+
+def test_rejected_before_any_state_change():
+    c, s, tid = _ready(enable_chain=True)
+    before = len(c.get_workspace("w").audit)
+    s("task.complete", workspace="w", **{"from": "agent:b"},
+      task_id=tid, output={}, confidence=0.5)
+    assert c.get_workspace("w").tasks[tid].state == "in_progress"
+    assert len(c.get_workspace("w").audit) == before
+
+
+def test_integer_confidence_still_accepted():
+    c, s, tid = _ready()
+    r = s("task.complete", workspace="w", **{"from": "agent:b"},
+          task_id=tid, output={}, confidence=1)
+    assert r["result"]["state"] == "completed"

--- a/packages/coordinator-py/tests/test_participant_rejoin.py
+++ b/packages/coordinator-py/tests/test_participant_rejoin.py
@@ -1,0 +1,63 @@
+"""
+Regression: participant.join must not replace an existing member. A re-join
+keeps the member's role, scopes and keys, refreshes only the verified identity
+binding, and never accepts self-asserted jwks for an already-admitted URI.
+Guards the 0.2.7 fix.
+"""
+from __future__ import annotations
+
+from chap_coordinator import Coordinator, CoordinatorOptions
+
+
+def _ready(**opts):
+    c = Coordinator(CoordinatorOptions(deterministic_ids=True, **opts))
+
+    def s(method, **params):
+        return c.dispatch({"jsonrpc": "2.0", "id": method, "method": method, "params": params})
+
+    s("workspace.create", workspace="w")
+    s("participant.join", workspace="w", **{"from": "human:alice"}, type="human",
+      role="reviewer", scopes=["approve"], jwks={"keys": [{"kid": "alice-1", "x": "A"}]})
+    return c, s
+
+
+def test_rejoin_keeps_role_scopes_and_key():
+    c, s = _ready()
+    s("participant.join", workspace="w", **{"from": "human:alice"}, type="human",
+      role="owner", jwks={"keys": [{"kid": "attacker", "x": "E"}]})
+    m = c.get_workspace("w").members["human:alice"]
+    assert m.role == "reviewer"
+    assert m.scopes == ["approve"]
+    assert [k.kid for k in m.keys] == ["alice-1"]
+
+
+def test_rejoin_ignores_self_asserted_jwks():
+    c, s = _ready()
+    s("participant.join", workspace="w", **{"from": "human:alice"}, type="human",
+      jwks={"keys": [{"kid": "attacker", "x": "E"}]})
+    m = c.get_workspace("w").members["human:alice"]
+    assert all(k.kid != "attacker" for k in m.keys)
+
+
+def test_rejoin_refreshes_verified_binding():
+    claims = {"good": {"sub": "alice", "auth_time": 111}}
+    c = Coordinator(CoordinatorOptions(deterministic_ids=True,
+                                       verify_oidc_token=lambda t: claims.get(t)))
+
+    def s(method, **params):
+        return c.dispatch({"jsonrpc": "2.0", "id": method, "method": method, "params": params})
+
+    s("workspace.create", workspace="w")
+    s("participant.join", workspace="w", **{"from": "human:alice"}, type="human")
+    s("participant.join", workspace="w", **{"from": "human:alice"}, type="human", oidc_token="good")
+    m = c.get_workspace("w").members["human:alice"]
+    assert m.oidc_sub == "alice"
+    assert m.oidc_auth_time == 111
+
+
+def test_new_member_with_jwks_registers_keys():
+    c, s = _ready()
+    s("participant.join", workspace="w", **{"from": "agent:new"}, type="agent",
+      jwks={"keys": [{"kid": "n1", "x": "N"}]})
+    m = c.get_workspace("w").members["agent:new"]
+    assert [k.kid for k in m.keys] == ["n1"]

--- a/packages/coordinator-py/tests/test_verify_chain_unchained.py
+++ b/packages/coordinator-py/tests/test_verify_chain_unchained.py
@@ -1,0 +1,51 @@
+"""
+Regression: audit.verify_chain must not report a clean log as tampered when the
+workspace has no chain. An unchained workspace is refused, and a workspace whose
+chain was enabled mid-life replays only from its first chained entry. Guards the
+0.2.7 fix.
+"""
+from __future__ import annotations
+
+from chap_coordinator import Coordinator, CoordinatorOptions
+from chap_coordinator.jsonrpc import E
+
+
+def _send(c):
+    def s(method, **params):
+        return c.dispatch({"jsonrpc": "2.0", "id": method, "method": method, "params": params})
+    return s
+
+
+def test_unchained_workspace_is_not_reported_tampered():
+    c = Coordinator(CoordinatorOptions(deterministic_ids=True))
+    s = _send(c)
+    s("workspace.create", workspace="w", profiles=["core/1.0"])
+    s("participant.join", workspace="w", **{"from": "agent:b"}, type="agent")
+    r = s("audit.verify_chain", workspace="w")
+    assert "error" in r
+    assert r["error"]["code"] == E.PARAMS
+    assert "Chain not enabled" in r["error"]["message"]
+
+
+def test_chain_enabled_midlife_verifies_from_first_chained_entry():
+    c = Coordinator(CoordinatorOptions(deterministic_ids=True))
+    s = _send(c)
+    s("workspace.create", workspace="w", profiles=["core/1.0"])
+    s("participant.join", workspace="w", **{"from": "human:a"}, type="human")
+    s("participant.join", workspace="w", **{"from": "agent:b"}, type="agent")
+    s("task.create", workspace="w", **{"from": "human:a"}, kind="k", input={}, assignee="agent:b")
+    s("workspace.set_profiles", workspace="w", **{"from": "human:a"},
+      profiles=["core/1.0", "audit-scitt/1.0"])
+    s("task.create", workspace="w", **{"from": "human:a"}, kind="k2", input={}, assignee="agent:b")
+    assert s("audit.verify_chain", workspace="w")["result"]["ok"] is True
+
+
+def test_chained_workspace_still_detects_tampering():
+    c = Coordinator(CoordinatorOptions(deterministic_ids=True, enable_chain=True))
+    s = _send(c)
+    s("workspace.create", workspace="w")
+    s("participant.join", workspace="w", **{"from": "agent:b"}, type="agent")
+    s("task.create", workspace="w", **{"from": "agent:b"}, task="t1")
+    assert s("audit.verify_chain", workspace="w")["result"]["ok"] is True
+    c.get_workspace("w").audit[-1].envelope["params"]["task"] = "TAMPERED"
+    assert "error" in s("audit.verify_chain", workspace="w")

--- a/packages/coordinator/tests/ingress_canonicalisation.test.ts
+++ b/packages/coordinator/tests/ingress_canonicalisation.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Regression: dispatch must reject an envelope it cannot canonicalise instead
+ * of letting a handler run and then throwing while linking the audit chain. A
+ * non-integer or unsafe-integer number is refused with PARAMS, before any state
+ * changes. Guards the 0.2.7 fix.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Coordinator } from "../src/coordinator.ts";
+import { E } from "../src/jsonrpc.ts";
+
+function ready(opts: Record<string, unknown> = {}) {
+  const c = new Coordinator({ deterministicIds: true, ...opts });
+  const s = (method: string, params: unknown): any =>
+    c.dispatch({ jsonrpc: "2.0", id: method, method, params } as never);
+  s("workspace.create", { workspace: "w" });
+  s("participant.join", { workspace: "w", from: "human:a", type: "human" });
+  s("participant.join", { workspace: "w", from: "agent:b", type: "agent" });
+  const tid = s("task.create", { workspace: "w", from: "human:a", kind: "k", input: {}, assignee: "agent:b" }).result.task_id;
+  s("task.update", { workspace: "w", from: "agent:b", task_id: tid, state: "in_progress" });
+  return { c, s, tid };
+}
+
+test("a non-integer number is rejected with PARAMS", () => {
+  const { s, tid } = ready();
+  const r = s("task.complete", { workspace: "w", from: "agent:b", task_id: tid, output: {}, confidence: 0.86 });
+  assert.equal(r.error.code, E.PARAMS);
+});
+
+test("an unsafe integer is rejected with PARAMS", () => {
+  const { s, tid } = ready();
+  const r = s("task.complete", { workspace: "w", from: "agent:b", task_id: tid, output: {}, confidence: 2 ** 53 });
+  assert.equal(r.error.code, E.PARAMS);
+});
+
+test("the reject happens before any state change", () => {
+  const { c, s, tid } = ready({ enableChain: true });
+  const ws = c.workspaces.get("w") as any;
+  const before = ws.audit.length;
+  s("task.complete", { workspace: "w", from: "agent:b", task_id: tid, output: {}, confidence: 0.5 });
+  assert.equal(ws.tasks.get(tid).state, "in_progress");
+  assert.equal(ws.audit.length, before);
+});
+
+test("an integer confidence is still accepted", () => {
+  const { s, tid } = ready();
+  const r = s("task.complete", { workspace: "w", from: "agent:b", task_id: tid, output: {}, confidence: 1 });
+  assert.equal(r.result.state, "completed");
+});

--- a/packages/coordinator/tests/participant_rejoin.test.ts
+++ b/packages/coordinator/tests/participant_rejoin.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Regression: participant.join must not replace an existing member. A re-join
+ * keeps the member's role, scopes and keys, refreshes only the verified identity
+ * binding, and never accepts self-asserted jwks for an already-admitted URI.
+ * Guards the 0.2.7 fix.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Coordinator } from "../src/coordinator.ts";
+
+function ready(opts: Record<string, unknown> = {}) {
+  const c = new Coordinator({ deterministicIds: true, ...opts });
+  const s = (method: string, params: unknown): any =>
+    c.dispatch({ jsonrpc: "2.0", id: method, method, params } as never);
+  s("workspace.create", { workspace: "w" });
+  s("participant.join", { workspace: "w", from: "human:alice", type: "human",
+    role: "reviewer", scopes: ["approve"], jwks: { keys: [{ kid: "alice-1", x: "A" }] } });
+  return { c, s };
+}
+
+test("a re-join keeps role, scopes and key", () => {
+  const { c, s } = ready();
+  s("participant.join", { workspace: "w", from: "human:alice", type: "human",
+    role: "owner", jwks: { keys: [{ kid: "attacker", x: "E" }] } });
+  const m = (c.workspaces.get("w") as any).members.get("human:alice");
+  assert.equal(m.role, "reviewer");
+  assert.deepEqual(m.scopes, ["approve"]);
+  assert.deepEqual(m.keys.map((k: any) => k.kid), ["alice-1"]);
+});
+
+test("a re-join ignores self-asserted jwks", () => {
+  const { c, s } = ready();
+  s("participant.join", { workspace: "w", from: "human:alice", type: "human",
+    jwks: { keys: [{ kid: "attacker", x: "E" }] } });
+  const m = (c.workspaces.get("w") as any).members.get("human:alice");
+  assert.ok(m.keys.every((k: any) => k.kid !== "attacker"));
+});
+
+test("a re-join refreshes the verified binding", () => {
+  const claims: Record<string, unknown> = { good: { sub: "alice", auth_time: 111 } };
+  const c = new Coordinator({ deterministicIds: true, verifyOidcToken: (t: string) => (claims[t] as any) ?? null });
+  const s = (method: string, params: unknown): any =>
+    c.dispatch({ jsonrpc: "2.0", id: method, method, params } as never);
+  s("workspace.create", { workspace: "w" });
+  s("participant.join", { workspace: "w", from: "human:alice", type: "human" });
+  s("participant.join", { workspace: "w", from: "human:alice", type: "human", oidc_token: "good" });
+  const m = (c.workspaces.get("w") as any).members.get("human:alice");
+  assert.equal(m.oidc_sub, "alice");
+  assert.equal(m.oidc_auth_time, 111);
+});
+
+test("a new member joining with jwks still registers keys", () => {
+  const { c, s } = ready();
+  s("participant.join", { workspace: "w", from: "agent:new", type: "agent",
+    jwks: { keys: [{ kid: "n1", x: "N" }] } });
+  const m = (c.workspaces.get("w") as any).members.get("agent:new");
+  assert.deepEqual(m.keys.map((k: any) => k.kid), ["n1"]);
+});

--- a/packages/coordinator/tests/verify_chain_unchained.test.ts
+++ b/packages/coordinator/tests/verify_chain_unchained.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Regression: audit.verify_chain must not report a clean log as tampered when
+ * the workspace has no chain. An unchained workspace is refused, and a workspace
+ * whose chain was enabled mid-life replays only from its first chained entry.
+ * Guards the 0.2.7 fix.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Coordinator } from "../src/coordinator.ts";
+import { E } from "../src/jsonrpc.ts";
+
+function send(c: Coordinator) {
+  return (method: string, params: unknown): any =>
+    c.dispatch({ jsonrpc: "2.0", id: method, method, params } as never);
+}
+
+test("an unchained workspace is not reported tampered", () => {
+  const c = new Coordinator({ deterministicIds: true });
+  const s = send(c);
+  s("workspace.create", { workspace: "w", profiles: ["core/1.0"] });
+  s("participant.join", { workspace: "w", from: "agent:b", type: "agent" });
+  const r = s("audit.verify_chain", { workspace: "w" });
+  assert.equal(r.error.code, E.PARAMS);
+  assert.ok(r.error.message.includes("Chain not enabled"));
+});
+
+test("a chain enabled mid-life verifies from the first chained entry", () => {
+  const c = new Coordinator({ deterministicIds: true });
+  const s = send(c);
+  s("workspace.create", { workspace: "w", profiles: ["core/1.0"] });
+  s("participant.join", { workspace: "w", from: "human:a", type: "human" });
+  s("participant.join", { workspace: "w", from: "agent:b", type: "agent" });
+  s("task.create", { workspace: "w", from: "human:a", kind: "k", input: {}, assignee: "agent:b" });
+  s("workspace.set_profiles", { workspace: "w", from: "human:a", profiles: ["core/1.0", "audit-scitt/1.0"] });
+  s("task.create", { workspace: "w", from: "human:a", kind: "k2", input: {}, assignee: "agent:b" });
+  assert.equal(s("audit.verify_chain", { workspace: "w" }).result.ok, true);
+});
+
+test("a chained workspace still detects tampering", () => {
+  const c = new Coordinator({ deterministicIds: true, enableChain: true });
+  const s = send(c);
+  s("workspace.create", { workspace: "w" });
+  s("participant.join", { workspace: "w", from: "agent:b", type: "agent" });
+  s("task.create", { workspace: "w", from: "agent:b", task: "t1" });
+  assert.equal(s("audit.verify_chain", { workspace: "w" }).result.ok, true);
+  const ws = c.workspaces.get("w") as any;
+  ws.audit[ws.audit.length - 1].envelope.params.task = "TAMPERED";
+  assert.ok("error" in s("audit.verify_chain", { workspace: "w" }));
+});


### PR DESCRIPTION
Fast-follow requested on #25: regression tests for the three fixes merged in
#21 (uncanonicalisable envelope), #23 (verify_chain on an unchained workspace)
and #25 (participant.join member replacement). Added to both references.

- `test_ingress_canonicalisation` / `ingress_canonicalisation.test.ts` — a
  non-integer and an unsafe integer are rejected with PARAMS, before any state
  change; an integer is still accepted.
- `test_verify_chain_unchained` / `verify_chain_unchained.test.ts` — the
  non-chain error case, the leading-unchained case (chain enabled mid-life),
  and that a chained workspace still detects tampering.
- `test_participant_rejoin` / `participant_rejoin.test.ts` — the key-merge
  semantics: role/scopes/keys preserved, verified binding refreshed,
  self-asserted jwks ignored, new-member join unaffected.

Each regression assertion was confirmed to fail on the pre-fix code. Python
suite 185, TypeScript 133; TS typecheck and schema check clean.
