### PR TITLE
Take deliberation vote weight from the opener, not the voter

### DIFF
--- a/packages/coordinator-py/chap_coordinator/profiles/deliberation.py
+++ b/packages/coordinator-py/chap_coordinator/profiles/deliberation.py
@@ -83,8 +83,8 @@ def _compute_outcome(delib: Deliberation) -> dict:
                 "vetoes": []}
 
     if kind == "weighted_vote":
-        yea_w = sum(weights.get(v["voter"], v.get("weight", 1.0)) for v in yea)
-        nay_w = sum(weights.get(v["voter"], v.get("weight", 1.0)) for v in nay)
+        yea_w = sum(weights.get(v["voter"], 1.0) for v in yea)
+        nay_w = sum(weights.get(v["voter"], 1.0) for v in nay)
         passed = yea_w >= params["threshold"]
         return {"outcome": "approved" if passed else "rejected",
                 "rule": delib.rule,
@@ -97,8 +97,8 @@ def _compute_outcome(delib: Deliberation) -> dict:
                     "rule": delib.rule,
                     "tally": {"yea": 0.0, "nay": 0.0},
                     "vetoes": [v["voter"] for v in vetoes]}
-        yea_w = sum(weights.get(v["voter"], v.get("weight", 1.0)) for v in yea)
-        nay_w = sum(weights.get(v["voter"], v.get("weight", 1.0)) for v in nay)
+        yea_w = sum(weights.get(v["voter"], 1.0) for v in yea)
+        nay_w = sum(weights.get(v["voter"], 1.0) for v in nay)
         passed = yea_w >= params["threshold"]
         return {"outcome": "approved" if passed else "rejected",
                 "rule": delib.rule,

--- a/packages/coordinator-py/tests/test_deliberation_weight.py
+++ b/packages/coordinator-py/tests/test_deliberation_weight.py
@@ -1,0 +1,40 @@
+"""
+Regression: a weighted_vote tally uses the weights the opener set at
+deliberate.open, not a weight the voter puts on their own vote. A voter not in
+the opener's map counts as 1.0. Guards the 0.2.7 fix.
+"""
+from __future__ import annotations
+
+from chap_coordinator import Coordinator, CoordinatorOptions
+
+
+def _open(rule, weights=None, participants=("human:a", "human:b")):
+    c = Coordinator(CoordinatorOptions(deterministic_ids=True))
+
+    def s(method, **params):
+        return c.dispatch({"jsonrpc": "2.0", "id": method, "method": method, "params": params})
+
+    s("workspace.create", workspace="w")
+    for u in participants:
+        s("participant.join", workspace="w", **{"from": u}, type="human")
+    opts = {"to": list(participants), "rule": rule}
+    if weights is not None:
+        opts["weights"] = weights
+    did = s("deliberate.open", workspace="w", **{"from": participants[0]}, **opts)["result"]["deliberation_id"]
+    return s, did
+
+
+def test_self_declared_weight_is_ignored():
+    s, did = _open("weighted_vote:2.0")
+    s("deliberate.vote", workspace="w", **{"from": "human:a"}, deliberation_id=did, vote="yea", weight=999)
+    r = s("deliberate.close", workspace="w", **{"from": "human:a"}, deliberation_id=did)
+    assert r["result"]["outcome"] == "rejected"
+    assert r["result"]["tally"]["yea"] == 1.0
+
+
+def test_opener_weight_is_authoritative():
+    s, did = _open("weighted_vote:2.0", weights={"human:a": 3.0})
+    s("deliberate.vote", workspace="w", **{"from": "human:a"}, deliberation_id=did, vote="yea", weight=999)
+    r = s("deliberate.close", workspace="w", **{"from": "human:a"}, deliberation_id=did)
+    assert r["result"]["outcome"] == "approved"
+    assert r["result"]["tally"]["yea"] == 3.0

--- a/packages/coordinator/src/profiles/deliberation.ts
+++ b/packages/coordinator/src/profiles/deliberation.ts
@@ -40,7 +40,7 @@ function computeOutcome(delib: Deliberation): Deliberation["outcome"] {
   const weights = delib.weights ?? {};
 
   const weighted = (vs: typeof yea) =>
-    vs.reduce((s, v) => s + (weights[v.voter] ?? v.weight ?? 1.0), 0);
+    vs.reduce((s, v) => s + (weights[v.voter] ?? 1.0), 0);
 
   if (parsed.kind === "any_one_approves") {
     return {

--- a/packages/coordinator/tests/deliberation_weight.test.ts
+++ b/packages/coordinator/tests/deliberation_weight.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Regression: a weighted_vote tally uses the weights the opener set at
+ * deliberate.open, not a weight the voter puts on their own vote. A voter not
+ * in the opener's map counts as 1.0. Guards the 0.2.7 fix.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Coordinator } from "../src/coordinator.ts";
+
+function open(rule: string, weights?: Record<string, number>) {
+  const c = new Coordinator({ deterministicIds: true });
+  const s = (method: string, params: unknown): any =>
+    c.dispatch({ jsonrpc: "2.0", id: method, method, params } as never);
+  s("workspace.create", { workspace: "w" });
+  s("participant.join", { workspace: "w", from: "human:a", type: "human" });
+  s("participant.join", { workspace: "w", from: "human:b", type: "human" });
+  const params: Record<string, unknown> = { workspace: "w", from: "human:a", to: ["human:a", "human:b"], rule };
+  if (weights) params.weights = weights;
+  const did = s("deliberate.open", params).result.deliberation_id;
+  return { s, did };
+}
+
+test("a self-declared vote weight is ignored", () => {
+  const { s, did } = open("weighted_vote:2.0");
+  s("deliberate.vote", { workspace: "w", from: "human:a", deliberation_id: did, vote: "yea", weight: 999 });
+  const r = s("deliberate.close", { workspace: "w", from: "human:a", deliberation_id: did });
+  assert.equal(r.result.outcome, "rejected");
+  assert.equal(r.result.tally.yea, 1.0);
+});
+
+test("the opener's weight is authoritative", () => {
+  const { s, did } = open("weighted_vote:2.0", { "human:a": 3.0 });
+  s("deliberate.vote", { workspace: "w", from: "human:a", deliberation_id: did, vote: "yea", weight: 999 });
+  const r = s("deliberate.close", { workspace: "w", from: "human:a", deliberation_id: did });
+  assert.equal(r.result.outcome, "approved");
+  assert.equal(r.result.tally.yea, 3.0);
+});


### PR DESCRIPTION
A `weighted_vote` tally fell back to a voter-supplied `weight` when the opener's
`weights` map did not list that voter, so a single participant could vote with an
arbitrary weight and pass the threshold alone.

The opener sets weights at `deliberate.open` (`deliberation.md §3`), keyed by
voter URI; the vote's `weight` field only echoes the opener-assigned value. A
voter not in the map now counts as `1.0` rather than whatever weight they sent.

Applied to both reference implementations. Python 174/174, adapters 69/69,
TypeScript 122/122; TS typecheck clean.

Closes #29
