### PR TITLE
Require membership and a non-terminal task for escalate.raise

### DIFF
--- a/packages/coordinator-py/chap_coordinator/coordinator.py
+++ b/packages/coordinator-py/chap_coordinator/coordinator.py
@@ -1118,9 +1118,15 @@ class Coordinator:
         ws = self.workspaces.get(p["workspace"])
         if not ws:
             return {"error": rpc_error(E.PARAMS, "Unknown workspace")}
+        not_member = self._require_member(ws, p.get("from"))
+        if not_member:
+            return not_member
         orig = ws.tasks.get(p["original_task_id"])
         if not orig:
             return {"error": rpc_error(E.PARAMS, "Unknown original task")}
+        if orig.state in ("completed", "cancelled", "superseded"):
+            return {"error": rpc_error(
+                E.PARAMS, f"Cannot escalate a terminal task: {orig.state}")}
         nt = p["new_task"]
         assignee = nt.get("assignee")
         if not assignee or assignee not in ws.members:

--- a/packages/coordinator-py/tests/test_escalate_terminal.py
+++ b/packages/coordinator-py/tests/test_escalate_terminal.py
@@ -1,0 +1,48 @@
+"""
+Regression: escalate.raise requires the caller to be a workspace member and
+refuses a terminal task. Per SPECIFICATION.md the transition is "any
+non-terminal -> escalated", with terminal states completed/cancelled/superseded.
+Guards the 0.2.7 fix.
+"""
+from __future__ import annotations
+
+from chap_coordinator import Coordinator, CoordinatorOptions
+from chap_coordinator.jsonrpc import E
+
+
+def _ready():
+    c = Coordinator(CoordinatorOptions(deterministic_ids=True))
+
+    def s(method, **params):
+        return c.dispatch({"jsonrpc": "2.0", "id": method, "method": method, "params": params})
+
+    s("workspace.create", workspace="w")
+    s("participant.join", workspace="w", **{"from": "human:a"}, type="human")
+    s("participant.join", workspace="w", **{"from": "agent:b"}, type="agent")
+    tid = s("task.create", workspace="w", **{"from": "human:a"},
+            kind="k", input={}, assignee="agent:b")["result"]["task_id"]
+    return s, tid
+
+
+def test_non_member_cannot_escalate():
+    s, tid = _ready()
+    r = s("escalate.raise", workspace="w", **{"from": "ghost:x"},
+          original_task_id=tid, new_task={"assignee": "agent:b"})
+    assert r["error"]["code"] == E.NOT_AUTHORISED
+
+
+def test_cannot_escalate_a_completed_task():
+    s, tid = _ready()
+    s("task.update", workspace="w", **{"from": "agent:b"}, task_id=tid, state="in_progress")
+    s("task.complete", workspace="w", **{"from": "agent:b"}, task_id=tid, output={})
+    r = s("escalate.raise", workspace="w", **{"from": "human:a"},
+          original_task_id=tid, new_task={"assignee": "agent:b"})
+    assert "error" in r
+    assert "terminal" in r["error"]["message"]
+
+
+def test_member_can_escalate_an_active_task():
+    s, tid = _ready()
+    r = s("escalate.raise", workspace="w", **{"from": "human:a"},
+          original_task_id=tid, new_task={"assignee": "agent:b"})
+    assert r["result"]["escalated_from"] == tid

--- a/packages/coordinator/src/coordinator.ts
+++ b/packages/coordinator/src/coordinator.ts
@@ -1061,8 +1061,13 @@ export class Coordinator {
     if (miss) return { error: rpcError(E.PARAMS, `Missing field: ${miss}`) };
     const ws = this.workspaces.get(p.workspace as string);
     if (!ws) return { error: rpcError(E.PARAMS, "Unknown workspace") };
+    const notMember = this.requireMember(ws, p.from);
+    if (notMember) return notMember;
     const orig = ws.tasks.get(p.original_task_id as string);
     if (!orig) return { error: rpcError(E.PARAMS, "Unknown original task") };
+    if (orig.state === "completed" || orig.state === "cancelled" || orig.state === "superseded") {
+      return { error: rpcError(E.PARAMS, `Cannot escalate a terminal task: ${orig.state}`) };
+    }
     const nt = p.new_task as Record<string, unknown>;
     const assignee = nt.assignee as string;
     if (!assignee || !ws.members.has(assignee)) {

--- a/packages/coordinator/tests/escalate_terminal.test.ts
+++ b/packages/coordinator/tests/escalate_terminal.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Regression: escalate.raise requires the caller to be a workspace member and
+ * refuses a terminal task. Per SPECIFICATION.md the transition is "any
+ * non-terminal -> escalated", with terminal states completed/cancelled/superseded.
+ * Guards the 0.2.7 fix.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Coordinator } from "../src/coordinator.ts";
+import { E } from "../src/jsonrpc.ts";
+
+function ready() {
+  const c = new Coordinator({ deterministicIds: true });
+  const s = (method: string, params: unknown): any =>
+    c.dispatch({ jsonrpc: "2.0", id: method, method, params } as never);
+  s("workspace.create", { workspace: "w" });
+  s("participant.join", { workspace: "w", from: "human:a", type: "human" });
+  s("participant.join", { workspace: "w", from: "agent:b", type: "agent" });
+  const tid = s("task.create", { workspace: "w", from: "human:a", kind: "k", input: {}, assignee: "agent:b" }).result.task_id;
+  return { s, tid };
+}
+
+test("a non-member cannot escalate", () => {
+  const { s, tid } = ready();
+  const r = s("escalate.raise", { workspace: "w", from: "ghost:x", original_task_id: tid, new_task: { assignee: "agent:b" } });
+  assert.equal(r.error.code, E.NOT_AUTHORISED);
+});
+
+test("a completed task cannot be escalated", () => {
+  const { s, tid } = ready();
+  s("task.update", { workspace: "w", from: "agent:b", task_id: tid, state: "in_progress" });
+  s("task.complete", { workspace: "w", from: "agent:b", task_id: tid, output: {} });
+  const r = s("escalate.raise", { workspace: "w", from: "human:a", original_task_id: tid, new_task: { assignee: "agent:b" } });
+  assert.ok(r.error.message.includes("terminal"));
+});
+
+test("a member can escalate an active task", () => {
+  const { s, tid } = ready();
+  const r = s("escalate.raise", { workspace: "w", from: "human:a", original_task_id: tid, new_task: { assignee: "agent:b" } });
+  assert.equal(r.result.escalated_from, tid);
+});


### PR DESCRIPTION
`escalate.raise` did not check the caller and had no guard on the original
task's state, so a non-member could escalate, and a completed (terminal) task
could be flipped to `escalated`.

The caller must now be a workspace member (as the other actor methods already
require via `_require_member`), and a task in a terminal state
(completed/cancelled/superseded) is refused, matching the transition table in
SPECIFICATION.md (any non-terminal -> escalated). Escalating a non-terminal
task such as an abstained one is unchanged.

Applied to both reference implementations, with regression tests. Python
177/177, adapters 69/69, TypeScript 125/125; TS typecheck clean.

Closes #31
