### PR TITLE
Reject decision tags that are not a list of strings

### DIFF
--- a/packages/coordinator-py/chap_coordinator/coordinator.py
+++ b/packages/coordinator-py/chap_coordinator/coordinator.py
@@ -141,6 +141,14 @@ def _missing(params: dict, fields: list[str]) -> str | None:
     return None
 
 
+def _tags_error(params: dict) -> dict | None:
+    tags = params.get("tags")
+    if tags is not None and (not isinstance(tags, list)
+                             or not all(isinstance(t, str) for t in tags)):
+        return {"error": rpc_error(E.PARAMS, "tags must be a list of strings")}
+    return None
+
+
 def _link_hash(envelope: dict, prev: str) -> str:
     """Chain link: sha256( JCS(envelope) || prev_hash )."""
     return sha256_hex(canonicalize(envelope) + prev.encode("utf-8"))
@@ -972,6 +980,9 @@ class Coordinator:
         miss = _missing(p, ["workspace", "from", "task_id"])
         if miss:
             return {"error": rpc_error(E.PARAMS, f"Missing field: {miss}")}
+        bad_tags = _tags_error(p)
+        if bad_tags:
+            return bad_tags
         ws = self.workspaces.get(p["workspace"])
         if not ws:
             return {"error": rpc_error(E.PARAMS, "Unknown workspace")}
@@ -1012,6 +1023,9 @@ class Coordinator:
         miss = _missing(p, ["workspace", "from", "task_id", "diff", "rationale"])
         if miss:
             return {"error": rpc_error(E.PARAMS, f"Missing field: {miss}")}
+        bad_tags = _tags_error(p)
+        if bad_tags:
+            return bad_tags
         ws = self.workspaces.get(p["workspace"])
         if not ws:
             return {"error": rpc_error(E.PARAMS, "Unknown workspace")}

--- a/packages/coordinator-py/tests/test_decision_tags.py
+++ b/packages/coordinator-py/tests/test_decision_tags.py
@@ -1,0 +1,47 @@
+"""
+Regression: decision tags must be a list of strings, per the schema
+(schemas/core/chap-task.schema.json). A non-string tag is rejected with PARAMS.
+Guards the 0.2.7 fix.
+"""
+from __future__ import annotations
+
+from chap_coordinator import Coordinator, CoordinatorOptions
+from chap_coordinator.jsonrpc import E
+
+
+def _ready_review():
+    c = Coordinator(CoordinatorOptions(deterministic_ids=True))
+
+    def s(method, **params):
+        return c.dispatch({"jsonrpc": "2.0", "id": method, "method": method, "params": params})
+
+    s("workspace.create", workspace="w")
+    s("participant.join", workspace="w", **{"from": "agent:b"}, type="agent")
+    s("participant.join", workspace="w", **{"from": "human:a"}, type="human")
+    tid = s("task.create", workspace="w", **{"from": "human:a"},
+            kind="k", input={}, assignee="agent:b")["result"]["task_id"]
+    s("review.request", workspace="w", **{"from": "agent:b"},
+      task_id=tid, to=["human:a"], artefact={"v": 1})
+    return s, tid
+
+
+def test_decide_rejects_non_string_tags():
+    s, tid = _ready_review()
+    r = s("decide.approve", workspace="w", **{"from": "human:a"},
+          task_id=tid, tags=[{"x": 1}, 123])
+    assert r["error"]["code"] == E.PARAMS
+
+
+def test_override_rejects_non_string_tags():
+    s, tid = _ready_review()
+    r = s("decide.override", workspace="w", **{"from": "human:a"}, task_id=tid,
+          diff=[{"op": "replace", "path": "/v", "value": 2}],
+          rationale="x", tags=["ok", 5])
+    assert r["error"]["code"] == E.PARAMS
+
+
+def test_string_tags_accepted():
+    s, tid = _ready_review()
+    r = s("decide.approve", workspace="w", **{"from": "human:a"},
+          task_id=tid, tags=["routine"])
+    assert r["result"]["state"] == "completed"

--- a/packages/coordinator/src/coordinator.ts
+++ b/packages/coordinator/src/coordinator.ts
@@ -123,6 +123,14 @@ function missing(params: Record<string, unknown>, fields: string[]): string | nu
   return null;
 }
 
+function tagsError(p: Record<string, unknown>): { error: ReturnType<typeof rpcError> } | null {
+  const tags = p.tags;
+  if (tags !== undefined && (!Array.isArray(tags) || !tags.every((t) => typeof t === "string"))) {
+    return { error: rpcError(E.PARAMS, "tags must be a list of strings") };
+  }
+  return null;
+}
+
 function linkHash(envelope: Envelope, prev: string): string {
   return sha256Hex(Buffer.concat([canonicalize(envelope), Buffer.from(prev, "utf-8")]));
 }
@@ -943,6 +951,8 @@ export class Coordinator {
   private opDecide(p: Record<string, unknown>, kind: "approve" | "reject"): ReturnType<Handler> {
     const miss = missing(p, ["workspace", "from", "task_id"]);
     if (miss) return { error: rpcError(E.PARAMS, `Missing field: ${miss}`) };
+    const badTags = tagsError(p);
+    if (badTags) return badTags;
     const ws = this.workspaces.get(p.workspace as string);
     if (!ws) return { error: rpcError(E.PARAMS, "Unknown workspace") };
     const notMember = this.requireMember(ws, p.from);
@@ -976,6 +986,8 @@ export class Coordinator {
   private opDecideOverride(p: Record<string, unknown>): ReturnType<Handler> {
     const miss = missing(p, ["workspace", "from", "task_id", "diff", "rationale"]);
     if (miss) return { error: rpcError(E.PARAMS, `Missing field: ${miss}`) };
+    const badTags = tagsError(p);
+    if (badTags) return badTags;
     const ws = this.workspaces.get(p.workspace as string);
     if (!ws) return { error: rpcError(E.PARAMS, "Unknown workspace") };
     const notMember = this.requireMember(ws, p.from);

--- a/packages/coordinator/tests/decision_tags.test.ts
+++ b/packages/coordinator/tests/decision_tags.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Regression: decision tags must be a list of strings, per the schema
+ * (schemas/core/chap-task.schema.json). A non-string tag is rejected with PARAMS.
+ * Guards the 0.2.7 fix.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Coordinator } from "../src/coordinator.ts";
+import { E } from "../src/jsonrpc.ts";
+
+function readyReview() {
+  const c = new Coordinator({ deterministicIds: true });
+  const s = (method: string, params: unknown): any =>
+    c.dispatch({ jsonrpc: "2.0", id: method, method, params } as never);
+  s("workspace.create", { workspace: "w" });
+  s("participant.join", { workspace: "w", from: "agent:b", type: "agent" });
+  s("participant.join", { workspace: "w", from: "human:a", type: "human" });
+  const tid = s("task.create", { workspace: "w", from: "human:a", kind: "k", input: {}, assignee: "agent:b" }).result.task_id;
+  s("review.request", { workspace: "w", from: "agent:b", task_id: tid, to: ["human:a"], artefact: { v: 1 } });
+  return { s, tid };
+}
+
+test("decide rejects non-string tags", () => {
+  const { s, tid } = readyReview();
+  const r = s("decide.approve", { workspace: "w", from: "human:a", task_id: tid, tags: [{ x: 1 }, 123] });
+  assert.equal(r.error.code, E.PARAMS);
+});
+
+test("override rejects non-string tags", () => {
+  const { s, tid } = readyReview();
+  const r = s("decide.override", {
+    workspace: "w", from: "human:a", task_id: tid,
+    diff: [{ op: "replace", path: "/v", value: 2 }], rationale: "x", tags: ["ok", 5],
+  });
+  assert.equal(r.error.code, E.PARAMS);
+});
+
+test("string tags are accepted", () => {
+  const { s, tid } = readyReview();
+  const r = s("decide.approve", { workspace: "w", from: "human:a", task_id: tid, tags: ["routine"] });
+  assert.equal(r.result.state, "completed");
+});


### PR DESCRIPTION
`decide.approve` / `decide.reject` / `decide.override` stored the `tags`
parameter verbatim, so an object or number could be recorded where the schema
(`schemas/core/chap-task.schema.json`) defines tags as an array of strings,
breaking the queryable-string contract.

Non-string tags are now rejected with PARAMS, via a small `_tags_error` /
`tagsError` helper alongside the existing `_missing` / `missing`.

Applied to both reference implementations, with regression tests. Python
177/177, adapters 69/69, TypeScript 125/125; TS typecheck clean.

Closes #34
