### PR TITLE
Do not co-register self-asserted keys for an identity-bound participant

### DIFF
--- a/packages/coordinator-py/chap_coordinator/coordinator.py
+++ b/packages/coordinator-py/chap_coordinator/coordinator.py
@@ -770,12 +770,12 @@ class Coordinator:
 
         attested = list(member.keys)
 
-        # security-signed/1.0: register any JWKs supplied in the join envelope.
+        # Self-asserted JWKs are ignored for an identity-bound participant: the
+        # verifier-pinned cnf.jwk / vp_jwk is the signing key (proof of possession).
         jwks = p.get("jwks")
-        if isinstance(jwks, dict):
+        if isinstance(jwks, dict) and not attested:
             for j in jwks.get("keys", []) or []:
                 if isinstance(j, dict) and j.get("kid"):
-                    # Skip if we already pinned via cnf.jwk
                     if not any(k.kid == j["kid"] for k in member.keys):
                         member.keys.append(KeyRecord(
                             jwk=j, kid=j["kid"], valid_from=now,

--- a/packages/coordinator-py/tests/test_cnf_jwk_binding.py
+++ b/packages/coordinator-py/tests/test_cnf_jwk_binding.py
@@ -1,0 +1,38 @@
+"""
+Regression: a self-asserted jwks is not co-registered for an identity-bound
+participant. When an OIDC/VC join pins a cnf.jwk, that verifier-attested key is
+the only signing key; a key the joiner also supplied is ignored so it cannot be
+used to sign as that identity. Guards the 0.2.7 fix.
+"""
+from __future__ import annotations
+
+from chap_coordinator import Coordinator, CoordinatorOptions
+
+
+def _verify_token(token):
+    if token == "alice-token":
+        return {"sub": "alice", "auth_time": 1747476000,
+                "cnf": {"jwk": {"kty": "OKP", "crv": "Ed25519",
+                                "kid": "device-key", "x": "DK"}}}
+    return None
+
+
+def test_self_asserted_jwks_ignored_when_oidc_bound():
+    c = Coordinator(CoordinatorOptions(deterministic_ids=True,
+                                       verify_oidc_token=_verify_token))
+    c.dispatch({"jsonrpc": "2.0", "id": "j", "method": "participant.join",
+                "params": {"workspace": "w", "from": "human:alice", "type": "human",
+                           "oidc_token": "alice-token",
+                           "jwks": {"keys": [{"kty": "OKP", "crv": "Ed25519",
+                                              "kid": "attacker", "x": "EVIL"}]}}})
+    keys = [k.kid for k in c.workspaces["w"].members["human:alice"].keys]
+    assert keys == ["device-key"]
+
+
+def test_self_asserted_jwks_registered_without_binding():
+    c = Coordinator(CoordinatorOptions(deterministic_ids=True))
+    c.dispatch({"jsonrpc": "2.0", "id": "j", "method": "participant.join",
+                "params": {"workspace": "w", "from": "agent:b", "type": "agent",
+                           "jwks": {"keys": [{"kid": "k1", "x": "K"}]}}})
+    keys = [k.kid for k in c.workspaces["w"].members["agent:b"].keys]
+    assert keys == ["k1"]

--- a/packages/coordinator/src/coordinator.ts
+++ b/packages/coordinator/src/coordinator.ts
@@ -763,9 +763,10 @@ export class Coordinator {
 
     const attested = [...member.keys];
 
-    // security-signed/1.0: register supplied JWKs
+    // Self-asserted JWKs are ignored for an identity-bound participant: the
+    // verifier-pinned cnf.jwk / vp_jwk is the signing key (proof of possession).
     const jwks = p.jwks as { keys?: Array<{ kid: string; [k: string]: unknown }> } | undefined;
-    if (jwks?.keys) {
+    if (jwks?.keys && attested.length === 0) {
       for (const j of jwks.keys) {
         if (j.kid && !member.keys.some(k => k.kid === j.kid)) {
           member.keys.push({ jwk: j as unknown as KeyRecord["jwk"], kid: j.kid, valid_from: now });

--- a/packages/coordinator/tests/cnf_jwk_binding.test.ts
+++ b/packages/coordinator/tests/cnf_jwk_binding.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Regression: a self-asserted jwks is not co-registered for an identity-bound
+ * participant. When an OIDC/VC join pins a cnf.jwk, that verifier-attested key is
+ * the only signing key; a key the joiner also supplied is ignored so it cannot be
+ * used to sign as that identity. Guards the 0.2.7 fix.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Coordinator } from "../src/coordinator.ts";
+
+function verifyToken(t: string) {
+  return t === "alice-token"
+    ? { sub: "alice", auth_time: 1747476000, cnf: { jwk: { kty: "OKP", crv: "Ed25519", kid: "device-key", x: "DK" } } }
+    : null;
+}
+
+test("self-asserted jwks are ignored when the participant is OIDC-bound", () => {
+  const c = new Coordinator({ deterministicIds: true, verifyOidcToken: verifyToken });
+  c.dispatch({ jsonrpc: "2.0", id: "j", method: "participant.join", params: {
+    workspace: "w", from: "human:alice", type: "human", oidc_token: "alice-token",
+    jwks: { keys: [{ kty: "OKP", crv: "Ed25519", kid: "attacker", x: "EVIL" }] } } } as never);
+  const m = (c.workspaces.get("w") as any).members.get("human:alice");
+  assert.deepEqual(m.keys.map((k: any) => k.kid), ["device-key"]);
+});
+
+test("self-asserted jwks are registered without an identity binding", () => {
+  const c = new Coordinator({ deterministicIds: true });
+  c.dispatch({ jsonrpc: "2.0", id: "j", method: "participant.join", params: {
+    workspace: "w", from: "agent:b", type: "agent",
+    jwks: { keys: [{ kid: "k1", x: "K" }] } } } as never);
+  const m = (c.workspaces.get("w") as any).members.get("agent:b");
+  assert.deepEqual(m.keys.map((k: any) => k.kid), ["k1"]);
+});


### PR DESCRIPTION
When `participant.join` carried a verified OIDC/VC binding that pinned a
`cnf.jwk` (or `vp_jwk`), the handler also registered any self-asserted `jwks`
from the same envelope, and signature verification accepts any registered key.
A participant holding a token that pins a device key could therefore register
their own key and sign as that identity with it, defeating the proof-of-possession
binding.

Self-asserted `jwks` are now ignored when a verifier-attested key was pinned; a
participant with no binding still registers supplied keys as before. This reuses
the `attested` capture added in #25.

Applied to both reference implementations, with regression tests. Python
176/176, adapters 69/69, TypeScript 124/124; TS typecheck clean.

Closes #36
