### PR TITLE
Rehydrate Member.keys and Task.review when loading a workspace

### DIFF
--- a/packages/coordinator-py/chap_coordinator/coordinator.py
+++ b/packages/coordinator-py/chap_coordinator/coordinator.py
@@ -152,7 +152,7 @@ def _rehydrate_workspace(data: dict) -> "Workspace":
     Mirror of `_snapshot_workspace`; the two should round-trip cleanly.
     """
     from .types import (
-        Workspace, Member, Task, TaskHistoryEntry, KeyRecord,
+        Workspace, Member, Task, TaskHistoryEntry, KeyRecord, ReviewState,
         WhisperPrompt, Deliberation, Handoff, HandoffTask, AuditEntry,
     )
 
@@ -162,9 +162,10 @@ def _rehydrate_workspace(data: dict) -> "Workspace":
     members = {
         k: Member(**v) for k, v in (data.get("members") or {}).items()
     }
-    # Member.keys can be a dict of KeyRecord; rehydrate those too.
     for m in members.values():
-        if isinstance(m.keys, dict):
+        if isinstance(m.keys, list):
+            m.keys = [KeyRecord(**k) if isinstance(k, dict) else k for k in m.keys]
+        elif isinstance(m.keys, dict):
             m.keys = {k: KeyRecord(**v) if isinstance(v, dict) else v
                       for k, v in m.keys.items()}
 
@@ -172,6 +173,8 @@ def _rehydrate_workspace(data: dict) -> "Workspace":
     for k, v in (data.get("tasks") or {}).items():
         v = dict(v)
         v["history"] = [TaskHistoryEntry(**h) for h in v.get("history", [])]
+        if isinstance(v.get("review"), dict):
+            v["review"] = ReviewState(**v["review"])
         tasks[k] = Task(**v)
 
     whispers = {

--- a/packages/coordinator-py/tests/test_rehydrate_keys_review.py
+++ b/packages/coordinator-py/tests/test_rehydrate_keys_review.py
@@ -1,0 +1,49 @@
+"""
+Regression: _rehydrate_workspace reconstructs Member.keys as KeyRecord objects
+and Task.review as a ReviewState, so a persisted workspace is usable after a
+restart -- an in-flight review can still be decided instead of raising on a
+raw dict. Guards the 0.2.7 fix.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict
+
+from chap_coordinator import Coordinator, CoordinatorOptions
+from chap_coordinator.coordinator import _rehydrate_workspace
+from chap_coordinator.types import KeyRecord, ReviewState
+
+
+def _built():
+    c = Coordinator(CoordinatorOptions(deterministic_ids=True))
+
+    def s(method, **params):
+        return c.dispatch({"jsonrpc": "2.0", "id": method, "method": method, "params": params})
+
+    s("workspace.create", workspace="w")
+    s("participant.join", workspace="w", **{"from": "human:a"}, type="human",
+      jwks={"keys": [{"kid": "k1", "x": "K"}]})
+    s("participant.join", workspace="w", **{"from": "agent:b"}, type="agent")
+    tid = s("task.create", workspace="w", **{"from": "human:a"},
+            kind="k", input={}, assignee="agent:b")["result"]["task_id"]
+    s("review.request", workspace="w", **{"from": "agent:b"},
+      task_id=tid, to=["human:a"], artefact={"v": 1})
+    return c, s, tid
+
+
+def test_member_keys_rehydrate_to_keyrecord():
+    c, _, _ = _built()
+    rt = _rehydrate_workspace(asdict(c.get_workspace("w")))
+    assert all(isinstance(k, KeyRecord) for k in rt.members["human:a"].keys)
+
+
+def test_task_review_rehydrates_to_reviewstate():
+    c, _, tid = _built()
+    rt = _rehydrate_workspace(asdict(c.get_workspace("w")))
+    assert isinstance(rt.tasks[tid].review, ReviewState)
+
+
+def test_in_review_task_is_decidable_after_restore():
+    c, s, tid = _built()
+    c.workspaces["w"] = _rehydrate_workspace(asdict(c.get_workspace("w")))
+    r = s("decide.approve", workspace="w", **{"from": "human:a"}, task_id=tid)
+    assert r["result"]["state"] == "completed"


### PR DESCRIPTION
`_rehydrate_workspace` round-trips dataclasses through `asdict`, but `Member.keys`
serialises to a list of dicts (the existing guard checked for a dict and never
fired) and `Task.review` was not reconstructed at all. After a restart the first
signed envelope hit `.kid` on a dict and any in-flight review hit `.requested_to`
on a dict. Both are now rebuilt into `KeyRecord` / `ReviewState`.

Python only; the TypeScript store reads plain JSON objects that already match the
shapes, so it is unaffected.

Python 177/177, includes regression tests.

Closes #38
