### PR TITLE
Base an override on the artefact under review, not a caller value

### DIFF
--- a/packages/coordinator-py/chap_coordinator/coordinator.py
+++ b/packages/coordinator-py/chap_coordinator/coordinator.py
@@ -1028,7 +1028,9 @@ class Coordinator:
         not_reviewer = self._require_reviewer(task, p.get("from"))
         if not_reviewer:
             return not_reviewer
-        base = p.get("based_on_artefact", task.pending_artefact)
+        # The override is of the artefact under review; use the coordinator's
+        # record, not a caller-supplied "before" that could be fabricated.
+        base = task.pending_artefact
         if base is None:
             return {"error": rpc_error(E.PARAMS, "No base artefact for override")}
         try:

--- a/packages/coordinator-py/tests/test_override_based_on.py
+++ b/packages/coordinator-py/tests/test_override_based_on.py
@@ -1,0 +1,34 @@
+"""
+Regression: decide.override records the artefact under review as its base, not a
+caller-supplied based_on_artefact. A fabricated "before" is ignored. Guards the
+0.2.7 fix.
+"""
+from __future__ import annotations
+
+from chap_coordinator import Coordinator, CoordinatorOptions
+
+
+def _ready_override():
+    c = Coordinator(CoordinatorOptions(deterministic_ids=True))
+
+    def s(method, **params):
+        return c.dispatch({"jsonrpc": "2.0", "id": method, "method": method, "params": params})
+
+    s("workspace.create", workspace="w")
+    s("participant.join", workspace="w", **{"from": "agent:b"}, type="agent")
+    s("participant.join", workspace="w", **{"from": "human:a"}, type="human")
+    tid = s("task.create", workspace="w", **{"from": "human:a"},
+            kind="k", input={}, assignee="agent:b")["result"]["task_id"]
+    s("review.request", workspace="w", **{"from": "agent:b"},
+      task_id=tid, to=["human:a"], artefact={"real": "pending"})
+    return c, s, tid
+
+
+def test_override_ignores_caller_supplied_based_on():
+    c, s, tid = _ready_override()
+    r = s("decide.override", workspace="w", **{"from": "human:a"}, task_id=tid,
+          based_on_artefact={"FORGED": "before"},
+          diff=[{"op": "add", "path": "/x", "value": 1}], rationale="x")
+    assert r["result"]["applied"] == {"real": "pending", "x": 1}
+    ov = list(c.get_workspace("w").overrides.values())[-1]
+    assert ov.based_on_artefact == {"real": "pending"}

--- a/packages/coordinator/src/coordinator.ts
+++ b/packages/coordinator/src/coordinator.ts
@@ -987,7 +987,9 @@ export class Coordinator {
     }
     const notReviewer = this.requireReviewer(task, p.from);
     if (notReviewer) return notReviewer;
-    const base = p.based_on_artefact !== undefined ? p.based_on_artefact : task.pending_artefact;
+    // The override is of the artefact under review; use the coordinator's
+    // record, not a caller-supplied "before" that could be fabricated.
+    const base = task.pending_artefact;
     if (base === undefined) return { error: rpcError(E.PARAMS, "No base artefact for override") };
     let applied: unknown;
     try {

--- a/packages/coordinator/tests/override_based_on.test.ts
+++ b/packages/coordinator/tests/override_based_on.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Regression: decide.override records the artefact under review as its base, not
+ * a caller-supplied based_on_artefact. A fabricated "before" is ignored. Guards
+ * the 0.2.7 fix.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Coordinator } from "../src/coordinator.ts";
+
+test("override ignores a caller-supplied based_on_artefact", () => {
+  const c = new Coordinator({ deterministicIds: true });
+  const s = (method: string, params: unknown): any =>
+    c.dispatch({ jsonrpc: "2.0", id: method, method, params } as never);
+  s("workspace.create", { workspace: "w" });
+  s("participant.join", { workspace: "w", from: "agent:b", type: "agent" });
+  s("participant.join", { workspace: "w", from: "human:a", type: "human" });
+  const tid = s("task.create", { workspace: "w", from: "human:a", kind: "k", input: {}, assignee: "agent:b" }).result.task_id;
+  s("review.request", { workspace: "w", from: "agent:b", task_id: tid, to: ["human:a"], artefact: { real: "pending" } });
+  const r = s("decide.override", {
+    workspace: "w", from: "human:a", task_id: tid,
+    based_on_artefact: { FORGED: "before" },
+    diff: [{ op: "add", path: "/x", value: 1 }], rationale: "x",
+  });
+  assert.deepEqual(r.result.applied, { real: "pending", x: 1 });
+  const ov = [...(c.workspaces.get("w") as any).overrides.values()].pop();
+  assert.deepEqual(ov.based_on_artefact, { real: "pending" });
+});


### PR DESCRIPTION
`decide.override` took its "before" state from a caller-supplied
`based_on_artefact` when present, so a reviewer could record an override against
a fabricated original, corrupting the before/after in the audit trail. The base
is now always `task.pending_artefact` -- the artefact the coordinator recorded at
`review.request`.

Applied to both reference implementations, with regression tests. Python 175/175,
TypeScript 123/123; TS typecheck clean. No test or adapter passes
`based_on_artefact`.

Closes #40
