### PR TITLE
Do not record read-only methods in the audit chain

### DIFF
--- a/packages/coordinator-py/chap_coordinator/coordinator.py
+++ b/packages/coordinator-py/chap_coordinator/coordinator.py
@@ -68,6 +68,14 @@ PRIVILEGED_METHODS = frozenset({
 })
 
 
+# Read-only methods return workspace state but do not mutate it, so they are not
+# recorded in the audit chain -- recording a read would grow and re-link it.
+_READ_ONLY_METHODS = frozenset({
+    "workspace.describe", "audit.read",
+    "audit.verify_chain", "audit.verify_receipt",
+})
+
+
 @dataclass
 class CoordinatorOptions:
     """Options controlling Coordinator behaviour."""
@@ -438,7 +446,7 @@ class Coordinator:
 
         # Record audit on successful operations that name a workspace
         ws_id = params.get("workspace")
-        if isinstance(ws_id, str):
+        if isinstance(ws_id, str) and method not in _READ_ONLY_METHODS:
             ws = self.workspaces.get(ws_id)
             if ws is not None:
                 self._record_audit(ws, envelope)

--- a/packages/coordinator-py/tests/test_reads_not_recorded.py
+++ b/packages/coordinator-py/tests/test_reads_not_recorded.py
@@ -1,0 +1,37 @@
+"""
+Regression: read-only methods (audit.read, workspace.describe,
+audit.verify_chain, audit.verify_receipt) do not append to the audit chain.
+Recording a read grew and re-linked the chain each time it was inspected.
+Guards the 0.2.7 fix.
+"""
+from __future__ import annotations
+
+from chap_coordinator import Coordinator, CoordinatorOptions
+
+
+def _ready(**opts):
+    c = Coordinator(CoordinatorOptions(deterministic_ids=True, **opts))
+
+    def s(method, **params):
+        return c.dispatch({"jsonrpc": "2.0", "id": method, "method": method, "params": params})
+
+    s("workspace.create", workspace="w")
+    s("participant.join", workspace="w", **{"from": "agent:b"}, type="agent")
+    return c, s
+
+
+def test_reads_do_not_grow_the_chain():
+    c, s = _ready(enable_chain=True)
+    n0 = len(c.get_workspace("w").audit)
+    for _ in range(3):
+        s("audit.read", workspace="w")
+    s("workspace.describe", workspace="w")
+    s("audit.verify_chain", workspace="w")
+    assert len(c.get_workspace("w").audit) == n0
+
+
+def test_writes_are_still_recorded():
+    c, s = _ready()
+    n0 = len(c.get_workspace("w").audit)
+    s("participant.join", workspace="w", **{"from": "human:a"}, type="human")
+    assert len(c.get_workspace("w").audit) == n0 + 1

--- a/packages/coordinator/src/coordinator.ts
+++ b/packages/coordinator/src/coordinator.ts
@@ -83,6 +83,12 @@ export const PRIVILEGED_METHODS = new Set<string>([
   "participant.rotate_key", "participant.revoke_key",
 ]);
 
+// Read-only methods return workspace state but do not mutate it, so they are not
+// recorded in the audit chain -- recording a read would grow and re-link it.
+const READ_ONLY_METHODS = new Set<string>([
+  "workspace.describe", "audit.read", "audit.verify_chain", "audit.verify_receipt",
+]);
+
 export interface CoordinatorOptions {
   deterministicIds?: boolean;
   deterministicClock?: boolean;
@@ -484,7 +490,7 @@ export class Coordinator {
 
     // Record audit on success
     const wsId = params.workspace as string | undefined;
-    if (typeof wsId === "string") {
+    if (typeof wsId === "string" && !READ_ONLY_METHODS.has(method)) {
       const ws = this.workspaces.get(wsId);
       if (ws) this.recordAudit(ws, envelope);
     }

--- a/packages/coordinator/tests/reads_not_recorded.test.ts
+++ b/packages/coordinator/tests/reads_not_recorded.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Regression: read-only methods (audit.read, workspace.describe,
+ * audit.verify_chain, audit.verify_receipt) do not append to the audit chain.
+ * Recording a read grew and re-linked the chain each time it was inspected.
+ * Guards the 0.2.7 fix.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Coordinator } from "../src/coordinator.ts";
+
+function ready(opts: Record<string, unknown> = {}) {
+  const c = new Coordinator({ deterministicIds: true, ...opts });
+  const s = (method: string, params: unknown): any =>
+    c.dispatch({ jsonrpc: "2.0", id: method, method, params } as never);
+  s("workspace.create", { workspace: "w" });
+  s("participant.join", { workspace: "w", from: "agent:b", type: "agent" });
+  return { c, s };
+}
+
+test("reads do not grow the chain", () => {
+  const { c, s } = ready({ enableChain: true });
+  const n0 = (c.workspaces.get("w") as any).audit.length;
+  for (let i = 0; i < 3; i++) s("audit.read", { workspace: "w" });
+  s("workspace.describe", { workspace: "w" });
+  s("audit.verify_chain", { workspace: "w" });
+  assert.equal((c.workspaces.get("w") as any).audit.length, n0);
+});
+
+test("writes are still recorded", () => {
+  const { c, s } = ready();
+  const n0 = (c.workspaces.get("w") as any).audit.length;
+  s("participant.join", { workspace: "w", from: "human:a", type: "human" });
+  assert.equal((c.workspaces.get("w") as any).audit.length, n0 + 1);
+});


### PR DESCRIPTION
`dispatch` recorded an audit entry for every successful method naming a
workspace, including reads. So `audit.read`, `workspace.describe` and
`audit.verify_chain` each appended an entry and re-linked the chain -- inspecting
or verifying the log changed it, and each read re-serialised the whole workspace.
These four read-only methods are now skipped.

Applied to both reference implementations, with regression tests. Python 176/176,
adapters 69/69, TypeScript 124/124; TS typecheck clean.

The in-process append lock and multi-writer compare-and-swap from the same
storage cluster are separate, heavier changes and are not part of this PR.

Closes #42
