### PR TITLE
Skip a corrupt row on load instead of dropping every workspace

### DIFF
--- a/packages/coordinator-py/chap_coordinator/storage/sqlite.py
+++ b/packages/coordinator-py/chap_coordinator/storage/sqlite.py
@@ -82,15 +82,20 @@ class SqliteStore:
         rows = self._conn.execute(
             "SELECT id, data, version, updated_at FROM chap_workspaces"
         ).fetchall()
-        return [
-            WorkspaceRecord(
-                id=row["id"],
-                data=json.loads(row["data"]),
-                version=row["version"],
-                updated_at=row["updated_at"],
-            )
-            for row in rows
-        ]
+        out: list[WorkspaceRecord] = []
+        for row in rows:
+            try:
+                out.append(WorkspaceRecord(
+                    id=row["id"],
+                    data=json.loads(row["data"]),
+                    version=row["version"],
+                    updated_at=row["updated_at"],
+                ))
+            except Exception:
+                # A single unreadable row must not discard every other
+                # workspace; skip it and keep the rest.
+                continue
+        return out
 
     def save(self, record: WorkspaceRecord) -> None:
         self._conn.execute(

--- a/packages/coordinator-py/tests/test_restore_corrupt_row.py
+++ b/packages/coordinator-py/tests/test_restore_corrupt_row.py
@@ -1,0 +1,18 @@
+"""
+Regression: a single unreadable row must not discard every other workspace.
+SqliteStore.load() skips a corrupt row and returns the rest, so one bad blob does
+not wipe the store on restart. Guards the 0.2.7 fix.
+"""
+from __future__ import annotations
+
+from chap_coordinator.storage.sqlite import SqliteStore
+from chap_coordinator.storage.store import WorkspaceRecord
+
+
+def test_load_skips_a_corrupt_row():
+    store = SqliteStore(":memory:")
+    for w in ("w1", "w2", "w3"):
+        store.save(WorkspaceRecord(id=w, data={"id": w}, version=1, updated_at="t"))
+    store._conn.execute("UPDATE chap_workspaces SET data='{bad json' WHERE id='w2'")
+    store._conn.commit()
+    assert sorted(r.id for r in store.load()) == ["w1", "w3"]

--- a/packages/coordinator/src/storage/sqlite.ts
+++ b/packages/coordinator/src/storage/sqlite.ts
@@ -110,12 +110,15 @@ export class SqliteStore implements Store {
       version: number;
       updated_at: string;
     }>;
-    return rows.map(r => ({
-      id: r.id,
-      data: JSON.parse(r.data),
-      version: r.version,
-      updated_at: r.updated_at,
-    }));
+    const out: WorkspaceRecord[] = [];
+    for (const r of rows) {
+      try {
+        out.push({ id: r.id, data: JSON.parse(r.data), version: r.version, updated_at: r.updated_at });
+      } catch {
+        // A single unreadable row must not discard every other workspace; skip it.
+      }
+    }
+    return out;
   }
 
   save(record: WorkspaceRecord): void {

--- a/packages/coordinator/tests/restore_corrupt_row.test.ts
+++ b/packages/coordinator/tests/restore_corrupt_row.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Regression: a single unreadable row must not discard every other workspace.
+ * SqliteStore.load() skips a corrupt row and returns the rest. Guards the 0.2.7
+ * fix. Skipped when better-sqlite3 is unavailable.
+ */
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let sqliteAvailable = true;
+try {
+  require("better-sqlite3");
+} catch {
+  sqliteAvailable = false;
+}
+
+describe("SqliteStore corrupt-row recovery", { skip: !sqliteAvailable }, () => {
+  test("load skips a corrupt row and keeps the rest", async () => {
+    const { SqliteStore } = await import("../src/storage/sqlite.js");
+    const tmp = mkdtempSync(join(tmpdir(), "chap-corrupt-"));
+    const store = new SqliteStore(join(tmp, "c.db"));
+    for (const w of ["w1", "w2", "w3"]) {
+      store.save({ id: w, data: { id: w }, version: 1, updated_at: "t" });
+    }
+    const Database = require("better-sqlite3");
+    const raw = new Database(join(tmp, "c.db"));
+    raw.prepare("UPDATE chap_workspaces SET data = ? WHERE id = ?").run("{bad json", "w2");
+    raw.close();
+    assert.deepEqual(store.load().map(r => r.id).sort(), ["w1", "w3"]);
+    rmSync(tmp, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
`SqliteStore.load()` built its record list eagerly, so a single row whose `data`
could not be parsed made the whole load throw; `_restore_from_store` swallowed it
and the coordinator booted empty. `load()` now skips an unreadable row and
returns the rest, so one bad blob no longer discards every workspace.

Applied to both reference implementations, with regression tests. Python 175/175;
the TypeScript regression test skips when better-sqlite3 is unavailable, matching
the existing storage tests. TS typecheck clean.

Closes #48
