### PR TITLE
Make crypto.sign emit the three-part wire tag the verifier expects

### DIFF
--- a/packages/coordinator-py/chap_coordinator/crypto.py
+++ b/packages/coordinator-py/chap_coordinator/crypto.py
@@ -64,9 +64,9 @@ def public_jwk(uri: str, key: Any | None = None) -> dict:
     }
 
 
-def sign(canonical_bytes: bytes, key: Any) -> str:
-    """Sign canonical bytes, returning ``ed25519:<base64>``."""
-    return "ed25519:" + _b64(key.sign(canonical_bytes))
+def sign(canonical_bytes: bytes, key: Any, kid: str) -> str:
+    """Sign canonical bytes, returning ``ed25519:<kid>:<base64>``."""
+    return "ed25519:" + kid + ":" + _b64(key.sign(canonical_bytes))
 
 
 def verify(canonical_bytes: bytes, sig: str, public_key: Any) -> bool:

--- a/packages/coordinator-py/tests/test_sign_helper_wire_format.py
+++ b/packages/coordinator-py/tests/test_sign_helper_wire_format.py
@@ -1,0 +1,31 @@
+"""
+Regression: the public ``crypto.sign`` helper must emit the ``ed25519:<kid>:<b64>``
+wire tag the coordinator verifies. A kid-less two-part tag is rejected as
+malformed (-32070), so the helper's output has to round-trip through dispatch.
+"""
+from __future__ import annotations
+
+from chap_coordinator import Coordinator, CoordinatorOptions
+from chap_coordinator.canonical import canonicalize
+from chap_coordinator import crypto
+
+
+def test_sign_helper_output_is_accepted_on_the_wire():
+    c = Coordinator(CoordinatorOptions(require_signatures=True))
+    sender = "human:alice"
+    priv = crypto.derive_private_key(sender)
+    jwk = crypto.public_jwk(sender)
+    kid = jwk["kid"]
+    c.dispatch({"jsonrpc": "2.0", "id": "j", "method": "participant.join",
+                "params": {"workspace": "w", "from": sender, "type": "human",
+                           "jwks": {"keys": [jwk]},
+                           "profiles": ["core/1.0", "security-signed/1.0"]}})
+
+    env = {"jsonrpc": "2.0", "id": "t", "method": "task.create",
+           "params": {"workspace": "w", "from": sender, "kind": "x",
+                      "input": {}, "assignee": sender}}
+    env["sig"] = crypto.sign(canonicalize(env), priv, kid)
+
+    assert env["sig"].count(":") == 2
+    r = c.dispatch(env)
+    assert "result" in r


### PR DESCRIPTION
`crypto.sign(canonical, key)` returned a two-part tag `ed25519:<base64>`, but the
coordinator's verifier requires exactly three parts `ed25519:<kid>:<base64>`, so
an envelope signed with the shipped helper was rejected as malformed (-32070).
The TypeScript `signEnvelope` already emits the three-part form.

`sign` now takes a `kid` and emits `ed25519:<kid>:<base64>`, matching both the
dispatch verifier and the TypeScript signer. The helper had no callers in the
tree, so nothing else changes. Regression test signs a real envelope with the
helper and asserts the coordinator accepts it (fails on the old two-arg helper).
Python 176/176.

Closes #50
