### PR TITLE
Sort canonical object keys by UTF-16 code unit to match the TS reference

### DIFF
--- a/packages/coordinator-py/chap_coordinator/canonical.py
+++ b/packages/coordinator-py/chap_coordinator/canonical.py
@@ -66,10 +66,14 @@ def _canon(obj: Any) -> str:
             raise ValueError(_NUMBER_RANGE_ERROR)
         return str(as_int)
     if isinstance(obj, dict):
-        items: list[str] = []
-        for key in sorted(obj.keys()):
+        for key in obj:
             if not isinstance(key, str):
                 raise TypeError("JCS object keys must be strings.")
+        items: list[str] = []
+        # JCS sorts keys by UTF-16 code unit, not code point; comparing the
+        # UTF-16-BE bytes reproduces the JavaScript reference's ordering for
+        # astral characters (surrogate pairs sort below U+E000..U+FFFF).
+        for key in sorted(obj, key=lambda k: k.encode("utf-16-be")):
             items.append(f"{json.dumps(key, ensure_ascii=False)}:{_canon(obj[key])}")
         return "{" + ",".join(items) + "}"
     if isinstance(obj, (list, tuple)):

--- a/packages/coordinator-py/tests/test_canonical_utf16_order.py
+++ b/packages/coordinator-py/tests/test_canonical_utf16_order.py
@@ -1,0 +1,19 @@
+"""
+Regression: JCS orders object keys by UTF-16 code unit, not Unicode code point.
+An astral key (encoded as a surrogate pair) must sort before a BMP key such as
+U+FFFF, so the Python canonicaliser agrees byte-for-byte with the TypeScript
+reference and the two coordinators produce the same hash.
+"""
+from __future__ import annotations
+
+from chap_coordinator.canonical import canonicalize
+
+
+def test_object_keys_sort_by_utf16_code_unit():
+    obj = {"\U0001F600": 1, "￿": 2}
+    assert canonicalize(obj) == '{"\U0001F600":1,"￿":2}'.encode("utf-8")
+
+
+def test_bmp_key_order_is_unchanged():
+    obj = {"b": 1, "a": 2, "Z": 3}
+    assert canonicalize(obj) == b'{"Z":3,"a":2,"b":1}'


### PR DESCRIPTION
The two coordinators must produce byte-identical canonical bytes for the same
value. They diverged on object key ordering: JCS (RFC 8785 §3.2.3) sorts member
names by UTF-16 code unit and the TypeScript reference does so, but the Python
reference used `sorted()`, which orders by Unicode code point. For a key outside
the BMP (surrogate pair, e.g. an emoji) the orders differ, so the same object
produced different bytes and different hashes on each implementation:

    Python:      {"￿":2,"😀":1}   -> sha256:92db27…
    TypeScript:  {"😀":1,"￿":2}   -> sha256:c6b1b9…

The Python canonicaliser now sorts keys by their UTF-16-BE encoding, which
reproduces the TypeScript ordering exactly. BMP-only objects (the common case)
are byte-for-byte unchanged. Regression test asserts an astral key sorts before
U+FFFF and that BMP ordering is unchanged; it fails on the old code-point sort.
Python 177/177.

Closes #52
