### PR TITLE
Bound JSON Patch op count and result size against amplification

### DIFF
--- a/conformance/json-patch-vectors.json
+++ b/conformance/json-patch-vectors.json
@@ -29,6 +29,7 @@
     { "name": "test mismatch",                    "doc": {"a": 1}, "patch": [{"op": "test", "path": "/a", "value": 2}] },
     { "name": "move into own child",              "doc": {"a": {"b": 1}}, "patch": [{"op": "move", "from": "/a", "path": "/a/c"}] },
     { "name": "unknown op",                       "doc": {"a": 1}, "patch": [{"op": "frobnicate", "path": "/a", "value": 2}] },
-    { "name": "remove root",                      "doc": {"a": 1}, "patch": [{"op": "remove", "path": ""}] }
+    { "name": "remove root",                      "doc": {"a": 1}, "patch": [{"op": "remove", "path": ""}] },
+    { "name": "copy bomb exceeds node cap",       "doc": {"a": [0]}, "patch": [{"op": "copy", "from": "/a", "path": "/a/-"}, {"op": "copy", "from": "/a", "path": "/a/-"}, {"op": "copy", "from": "/a", "path": "/a/-"}, {"op": "copy", "from": "/a", "path": "/a/-"}, {"op": "copy", "from": "/a", "path": "/a/-"}, {"op": "copy", "from": "/a", "path": "/a/-"}, {"op": "copy", "from": "/a", "path": "/a/-"}, {"op": "copy", "from": "/a", "path": "/a/-"}, {"op": "copy", "from": "/a", "path": "/a/-"}, {"op": "copy", "from": "/a", "path": "/a/-"}, {"op": "copy", "from": "/a", "path": "/a/-"}, {"op": "copy", "from": "/a", "path": "/a/-"}, {"op": "copy", "from": "/a", "path": "/a/-"}, {"op": "copy", "from": "/a", "path": "/a/-"}, {"op": "copy", "from": "/a", "path": "/a/-"}, {"op": "copy", "from": "/a", "path": "/a/-"}, {"op": "copy", "from": "/a", "path": "/a/-"}, {"op": "copy", "from": "/a", "path": "/a/-"}, {"op": "copy", "from": "/a", "path": "/a/-"}, {"op": "copy", "from": "/a", "path": "/a/-"}] }
   ]
 }

--- a/packages/coordinator-py/chap_coordinator/patch.py
+++ b/packages/coordinator-py/chap_coordinator/patch.py
@@ -182,12 +182,36 @@ def _apply_one(doc: Any, op: dict) -> Any:
     raise PatchError(f"Unsupported op: {kind!r}")
 
 
+MAX_PATCH_OPS = 1000
+MAX_DOCUMENT_NODES = 100_000
+
+
+def _node_count(value: Any) -> int:
+    if isinstance(value, dict):
+        return 1 + sum(_node_count(v) for v in value.values())
+    if isinstance(value, list):
+        return 1 + sum(_node_count(v) for v in value)
+    return 1
+
+
 def apply_json_patch(doc: Any, patch: list[dict]) -> Any:
     """Apply an RFC 6902 JSON Patch, returning the patched document.
 
-    The input ``doc`` is not mutated.
+    The input ``doc`` is not mutated. ``copy``/``move`` can amplify the
+    document (copying a node into itself doubles it each step), so the op
+    count and the working document's node count are bounded; both limits
+    match the TypeScript reference so a patch refused by one is refused by
+    the other.
     """
+    if len(patch) > MAX_PATCH_OPS:
+        raise PatchError(
+            f"Patch has too many operations ({len(patch)} > {MAX_PATCH_OPS})"
+        )
     out = copy.deepcopy(doc)
     for op in patch:
         out = _apply_one(out, op)
+        if _node_count(out) > MAX_DOCUMENT_NODES:
+            raise PatchError(
+                f"Patched document exceeds the node limit ({MAX_DOCUMENT_NODES})"
+            )
     return out

--- a/packages/coordinator/src/patch.ts
+++ b/packages/coordinator/src/patch.ts
@@ -218,10 +218,33 @@ function applyOne(doc: any, op: JsonPatchOp): any {
   throw new PatchError(`Unsupported op: ${JSON.stringify(kind)}`);
 }
 
+const MAX_PATCH_OPS = 1000;
+const MAX_DOCUMENT_NODES = 100_000;
+
+function nodeCount(value: unknown): number {
+  if (Array.isArray(value)) {
+    let n = 1;
+    for (const v of value) n += nodeCount(v);
+    return n;
+  }
+  if (value !== null && typeof value === "object") {
+    let n = 1;
+    for (const v of Object.values(value as Record<string, unknown>)) n += nodeCount(v);
+    return n;
+  }
+  return 1;
+}
+
 export function applyJsonPatch(doc: unknown, ops: JsonPatchOp[]): unknown {
+  if (ops.length > MAX_PATCH_OPS) {
+    throw new PatchError(`Patch has too many operations (${ops.length} > ${MAX_PATCH_OPS})`);
+  }
   let out: any = JSON.parse(JSON.stringify(doc));
   for (const op of ops) {
     out = applyOne(out, op);
+    if (nodeCount(out) > MAX_DOCUMENT_NODES) {
+      throw new PatchError(`Patched document exceeds the node limit (${MAX_DOCUMENT_NODES})`);
+    }
   }
   return out;
 }


### PR DESCRIPTION
A `decide.override` JSON Patch could exhaust memory. `copy`/`move` deep-copy the
source with no limit, and because `copy` reads the current working document,
copying a node into itself doubles it each step — a ~20-op patch expands to
millions of nodes (2^n growth) while being applied.

`apply_json_patch` now bounds the operation count (`MAX_PATCH_OPS = 1000`) and
the working document's node count (`MAX_DOCUMENT_NODES = 100_000`), raising
`PatchError` past either limit, which the `decide.override` handler already
surfaces as a clean error. Node count (not byte size) keeps the Python and
TypeScript references rejecting exactly the same patches. `copy`/`move` are
unchanged for normal use, and a copy-bomb case is added to the shared reject
vectors (it fails on the current code and passes after this change).

Thresholds are generous relative to the conformance vectors (max 5 nodes / 2
ops) and easy to tune; both references and the vector are updated together.
Python 177/177, TS 122/122, typecheck clean.

Closes #54
