### PR TITLE
Harden the Python reference server against malformed requests

### DIFF
--- a/reference/python/server.py
+++ b/reference/python/server.py
@@ -25,6 +25,31 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 from chap_coordinator import Coordinator, CoordinatorOptions
 
+MAX_BODY_BYTES = 1_000_000
+MAX_JSON_DEPTH = 64
+
+
+def _within_depth(value: object, limit: int) -> bool:
+    """Iteratively check nesting depth. dispatch/deepcopy/canonicalize
+    recurse, so an over-deep envelope is rejected before it reaches them."""
+    stack = [(value, 1)]
+    while stack:
+        node, depth = stack.pop()
+        if depth > limit:
+            return False
+        if isinstance(node, dict):
+            for v in node.values():
+                stack.append((v, depth + 1))
+        elif isinstance(node, list):
+            for v in node:
+                stack.append((v, depth + 1))
+    return True
+
+
+def _parse_error(message: str) -> dict:
+    return {"jsonrpc": "2.0", "id": None,
+            "error": {"code": -32700, "message": message}}
+
 
 def make_handler(coord: Coordinator):
     class Handler(BaseHTTPRequestHandler):
@@ -47,14 +72,23 @@ def make_handler(coord: Coordinator):
                 self.wfile.write(b'{"error":"POST /chap"}')
                 return
 
-            length = int(self.headers.get("Content-Length") or 0)
-            raw = self.rfile.read(length).decode("utf-8")
+            header = self.headers.get("Content-Length")
             try:
+                length = int(header) if header is not None else 0
+            except ValueError:
+                self._write(400, _parse_error("Invalid Content-Length header"))
+                return
+            if length < 0 or length > MAX_BODY_BYTES:
+                self._write(400, _parse_error("Content-Length out of range"))
+                return
+            try:
+                raw = self.rfile.read(length).decode("utf-8")
                 envelope = json.loads(raw)
-            except json.JSONDecodeError:
-                resp = {"jsonrpc": "2.0", "id": None,
-                        "error": {"code": -32700, "message": "Malformed JSON"}}
-                self._write(400, resp)
+            except (ValueError, UnicodeDecodeError, RecursionError):
+                self._write(400, _parse_error("Malformed JSON"))
+                return
+            if not _within_depth(envelope, MAX_JSON_DEPTH):
+                self._write(400, _parse_error("Envelope nesting too deep"))
                 return
 
             response = coord.dispatch(envelope)

--- a/reference/python/test_server_hardening.py
+++ b/reference/python/test_server_hardening.py
@@ -1,0 +1,108 @@
+"""
+Regression: the reference server must turn malformed requests into clean
+protocol errors instead of crashing or hanging the request thread. A
+non-numeric or negative Content-Length and a deeply nested body used to raise
+uncaught exceptions (a negative length even triggered an unbounded read).
+"""
+from __future__ import annotations
+
+import json
+import socket
+import sys
+import threading
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+
+THIS = Path(__file__).resolve()
+sys.path.insert(0, str(THIS.parent))
+sys.path.insert(0, str(THIS.parents[2] / "packages" / "coordinator-py"))
+
+import pytest
+
+from chap_coordinator import Coordinator, CoordinatorOptions
+from server import make_handler
+
+
+@pytest.fixture
+def address():
+    coord = Coordinator(CoordinatorOptions(
+        default_profiles=["core/1.0", "review/1.0"],
+    ))
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), make_handler(coord))
+    thread = threading.Thread(target=srv.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield srv.server_address
+    finally:
+        srv.shutdown()
+
+
+def _post(address, content_length, body: bytes, timeout: float = 3.0) -> bytes:
+    host, port = address
+    s = socket.create_connection((host, port), timeout=timeout)
+    s.settimeout(timeout)
+    request = (
+        f"POST /chap HTTP/1.0\r\n"
+        f"Host: localhost\r\n"
+        f"Content-Type: application/json\r\n"
+        f"Content-Length: {content_length}\r\n"
+        f"\r\n"
+    ).encode("utf-8") + body
+    s.sendall(request)
+    buf = b""
+    try:
+        while True:
+            chunk = s.recv(4096)
+            if not chunk:
+                break
+            buf += chunk
+    except socket.timeout:
+        pass
+    finally:
+        s.close()
+    return buf
+
+
+def _body(raw: bytes):
+    if b"\r\n\r\n" not in raw:
+        return None
+    payload = raw.split(b"\r\n\r\n", 1)[1]
+    if not payload:
+        return None
+    return json.loads(payload.decode("utf-8"))
+
+
+def test_non_numeric_content_length(address):
+    resp = _body(_post(address, "abc", b"{}"))
+    assert resp is not None and resp["error"]["code"] == -32700
+
+
+def test_negative_content_length(address):
+    resp = _body(_post(address, "-1", b""))
+    assert resp is not None and resp["error"]["code"] == -32700
+
+
+def test_deeply_nested_body_rejected(address):
+    depth = 200
+    body = ('{"a":' * depth + "1" + "}" * depth).encode("utf-8")
+    resp = _body(_post(address, str(len(body)), body))
+    assert resp is not None
+    assert resp["error"]["message"] == "Envelope nesting too deep"
+
+
+def test_valid_request_still_works(address):
+    env = {"jsonrpc": "2.0", "id": "1", "method": "workspace.create",
+           "params": {"workspace": "w", "profiles": ["core/1.0"]}}
+    body = json.dumps(env).encode("utf-8")
+    resp = _body(_post(address, str(len(body)), body))
+    assert resp is not None and "result" in resp
+
+
+def test_within_depth_helper():
+    from server import _within_depth
+    assert _within_depth({"a": [1, 2, {"b": 3}]}, 64)
+    node = inner = {}
+    for _ in range(100):
+        inner["x"] = {}
+        inner = inner["x"]
+    assert not _within_depth(node, 64)


### PR DESCRIPTION
The Python reference server handled only a JSON decode error; three other inputs
crashed or hung the request thread:

- `int(Content-Length)` raised on a non-numeric header;
- a negative `Content-Length` made `rfile.read(-1)` an unbounded read that hangs;
- a deeply nested body raised `RecursionError` (not `JSONDecodeError`) in the
  parser or in `dispatch`/`deepcopy`/`canonicalize`.

`Content-Length` is now validated (non-negative, within `MAX_BODY_BYTES`), the
parse guard returns `-32700` for any read/parse failure, and envelope nesting is
bounded with an iterative depth check before dispatch. Raising the recursion
limit would only move the cliff, so the input is bounded instead.

Regression tests use raw-socket requests to exercise the exact headers: a
non-numeric and a negative `Content-Length`, a deeply nested body, plus a valid
request to confirm the happy path is unchanged. The three malformed cases fail on
the current server (crash / hang / wrong response) and pass after this change.
The A2A and MCP reference servers don't use this raw HTTP path, so they're not
touched.

Closes #58
