### PR TITLE
Bind participant.rotate_key to the old signing key

### DIFF
--- a/packages/coordinator-py/chap_coordinator/coordinator.py
+++ b/packages/coordinator-py/chap_coordinator/coordinator.py
@@ -398,6 +398,13 @@ class Coordinator:
             sig_err = self._verify_signature(envelope)
             if sig_err:
                 return make_response(env_id, error=sig_err)
+            if method == "participant.rotate_key":
+                signing_kid = envelope["sig"].split(":", 2)[1]
+                old_kid = params.get("old_kid")
+                if old_kid is not None and signing_kid != old_kid:
+                    return make_response(env_id, error=rpc_error(
+                        E.SIG_ROTATION_KEY_MISMATCH,
+                        "Rotation must be signed with the old key"))
 
         # identity-oidc/1.0: step-up freshness check on privileged methods.
         if self.options.enforce_step_up and method in PRIVILEGED_METHODS:

--- a/packages/coordinator-py/chap_coordinator/profiles/security_signed.py
+++ b/packages/coordinator-py/chap_coordinator/profiles/security_signed.py
@@ -55,14 +55,6 @@ def register_security_signed(coord: "Coordinator") -> None:
             return {"error": rpc_error(E.SIG_KEY_REVOKED,
                                        f"Key {old_kid} is revoked")}
 
-        # The spec says the rotation message MUST be signed with the old key.
-        # If require_signatures is on, the dispatch layer has already verified
-        # the envelope; we additionally check that the signing kid matches
-        # the old_kid named in params.
-        envelope_sig = p.get("_envelope_sig")  # populated by dispatch wrapper
-        # Pragmatic: if a signature was supplied, ensure the kid matches.
-        # The full top-level sig verification path is at dispatch time.
-
         new_jwk = p["new_jwk"]
         if not isinstance(new_jwk, dict) or "kid" not in new_jwk:
             return {"error": rpc_error(E.PARAMS, "new_jwk must include kid")}

--- a/packages/coordinator-py/tests/test_identity_and_signed.py
+++ b/packages/coordinator-py/tests/test_identity_and_signed.py
@@ -192,6 +192,34 @@ def test_participant_rotate_key():
     assert new.valid_from is not None
 
 
+def test_rotate_key_must_be_signed_with_the_old_key():
+    c = Coordinator(CoordinatorOptions(require_signatures=True))
+    c.dispatch({"jsonrpc": "2.0", "id": "1", "method": "workspace.create",
+                "params": {"workspace": "w"}})
+    sk1, pub1 = _gen_keypair()
+    sk2, pub2 = _gen_keypair()
+    jwk1 = {"kty": "OKP", "crv": "Ed25519", "kid": "k1", "x": _b64url_nopad(pub1)}
+    jwk2 = {"kty": "OKP", "crv": "Ed25519", "kid": "k2", "x": _b64url_nopad(pub2)}
+    c.dispatch({"jsonrpc": "2.0", "id": "2", "method": "participant.join",
+                "params": {"workspace": "w", "from": "human:alice", "type": "human",
+                           "jwks": {"keys": [jwk1, jwk2]},
+                           "profiles": ["core/1.0", "security-signed/1.0"]}})
+    _, pub3 = _gen_keypair()
+    jwk3 = {"kty": "OKP", "crv": "Ed25519", "kid": "k3", "x": _b64url_nopad(pub3)}
+
+    def rotate(sk, kid):
+        env = {"jsonrpc": "2.0", "id": "r", "method": "participant.rotate_key",
+               "params": {"workspace": "w", "from": "human:alice",
+                          "old_kid": "k1", "new_jwk": jwk3}}
+        return c.dispatch(_sign_envelope(sk, env, kid))
+
+    signed_with_wrong_key = rotate(sk2, "k2")
+    assert signed_with_wrong_key["error"]["code"] == -32073
+
+    signed_with_old_key = rotate(sk1, "k1")
+    assert signed_with_old_key["result"]["rotated"] is True
+
+
 def test_participant_revoke_key():
     coord = Coordinator(CoordinatorOptions(
         deterministic_ids=True, deterministic_clock=True,

--- a/packages/coordinator/src/coordinator.ts
+++ b/packages/coordinator/src/coordinator.ts
@@ -433,6 +433,14 @@ export class Coordinator {
     if (this.options.requireSignatures && method !== "participant.join" && method !== "workspace.create") {
       const sigErr = this.verifySignature(envelope);
       if (sigErr) return reply(envelope, { error: sigErr });
+      if (method === "participant.rotate_key") {
+        const signingKid = (envelope.sig as string).split(":")[1];
+        const oldKid = params.old_kid as string | undefined;
+        if (oldKid !== undefined && signingKid !== oldKid) {
+          return reply(envelope, { error: rpcError(E.SIG_ROTATION_KEY_MISMATCH,
+            "Rotation must be signed with the old key") });
+        }
+      }
     }
 
     // identity-oidc/1.0: step-up freshness on privileged methods.

--- a/packages/coordinator/tests/identity_and_signed.test.ts
+++ b/packages/coordinator/tests/identity_and_signed.test.ts
@@ -114,6 +114,27 @@ test("participant.rotate_key sets valid_until on old key", () => {
   assert.ok(old.valid_until !== undefined);
 });
 
+test("participant.rotate_key must be signed with the old key", () => {
+  const c = new Coordinator({ requireSignatures: true });
+  const k1 = genKeypair();
+  const k2 = genKeypair();
+  const k3 = genKeypair();
+  c.dispatch({ jsonrpc: "2.0", id: "1", method: "workspace.create",
+    params: { workspace: "w" }});
+  c.dispatch({ jsonrpc: "2.0", id: "2", method: "participant.join",
+    params: { workspace: "w", from: "human:alice", type: "human",
+              jwks: { keys: [k1.jwk, k2.jwk] },
+              profiles: ["core/1.0", "security-signed/1.0"] }});
+
+  const rotate = (sk: KeyObject, kid: string) =>
+    c.dispatch(signed({ jsonrpc: "2.0", id: "r", method: "participant.rotate_key",
+      params: { workspace: "w", from: "human:alice",
+                old_kid: k1.jwk.kid, new_jwk: k3.jwk }}, sk, kid));
+
+  assert.equal((rotate(k2.sk, k2.jwk.kid).error as { code: number }).code, -32073);
+  assert.ok((rotate(k1.sk, k1.jwk.kid).result as { rotated: boolean }).rotated);
+});
+
 test("participant.revoke_key marks the key revoked", () => {
   const c = new Coordinator({ deterministicIds: true, deterministicClock: true });
   const k = genKeypair();


### PR DESCRIPTION
Closes #46.

Under `require_signatures` the general path already requires the envelope to be signed
by a valid key of `from`, so the spoofed-`from` takeover is the unsigned case (the
transport's job). The real gap is that the `-32073` old-key binding was dead code: the
signing kid never reached the `rotate_key` handler (`_envelope_sig` was read but never
populated), so a member could rotate one key while signing with another.

After signature verification, dispatch now requires the signing kid to equal `old_kid`
for `participant.rotate_key` and emits `-32073` (`SIG_ROTATION_KEY_MISMATCH`) otherwise.
A missing `old_kid` still falls through to the handler's clean "missing field" error.
The unused `_envelope_sig` placeholder is removed. Unsigned rotation stays
transport-delegated (the check only runs under `require_signatures`).

Kept minimal per the discussion: "sign with the old key" proves control of the current
key but isn't compromise-resilient; stronger key lifecycle belongs in the identity layer,
not `security-signed`.

Regression test (both refs): a member with two keys rotating `k1` while signing with `k2`
is rejected `-32073`; signing with `k1` succeeds. Fails on current `main`. Python 207/207,
TS 147/147, typecheck clean.
