### PR TITLE
Gate participant.revoke_key to self or an admin-role member

### DIFF
--- a/packages/coordinator-py/chap_coordinator/profiles/security_signed.py
+++ b/packages/coordinator-py/chap_coordinator/profiles/security_signed.py
@@ -86,6 +86,13 @@ def register_security_signed(coord: "Coordinator") -> None:
         for f in ("target_uri", "kid"):
             if f not in p:
                 return {"error": rpc_error(E.PARAMS, f"Missing field: {f}")}
+        sender = p.get("from")
+        if sender != p["target_uri"]:
+            caller = ws.members.get(sender) if sender else None
+            if caller is None or caller.role != "admin":
+                return {"error": rpc_error(
+                    E.NOT_AUTHORISED,
+                    "Revoking another member's key requires the admin role")}
         member = ws.members.get(p["target_uri"])
         if not member:
             return {"error": rpc_error(E.SIG_KEY_NOT_FOUND,

--- a/packages/coordinator-py/tests/test_identity_and_signed.py
+++ b/packages/coordinator-py/tests/test_identity_and_signed.py
@@ -207,6 +207,11 @@ def test_participant_revoke_key():
                     "params": {"workspace": "wsp_rv",
                                "from": "human:alice@x", "type": "human",
                                "role": "r", "jwks": {"keys": [jwk]}}})
+    coord.dispatch({"jsonrpc": "2.0", "id": "2a",
+                    "method": "participant.join",
+                    "params": {"workspace": "wsp_rv",
+                               "from": "human:admin@x", "type": "human",
+                               "role": "admin"}})
     r = coord.dispatch({"jsonrpc": "2.0", "id": "3",
                         "method": "participant.revoke_key",
                         "params": {"workspace": "wsp_rv",
@@ -215,6 +220,30 @@ def test_participant_revoke_key():
                                    "kid": "k-1",
                                    "reason": "test"}})
     assert r["result"]["revoked"] is True
+
+
+def test_revoke_key_requires_self_or_admin():
+    c = Coordinator(CoordinatorOptions())
+    c.dispatch({"jsonrpc": "2.0", "id": "1", "method": "workspace.create",
+                "params": {"workspace": "w"}})
+    for who in ("human:alice", "human:bob"):
+        _, pub = _gen_keypair()
+        jwk = {"kty": "OKP", "crv": "Ed25519", "kid": who, "x": _b64url_nopad(pub)}
+        c.dispatch({"jsonrpc": "2.0", "id": "j", "method": "participant.join",
+                    "params": {"workspace": "w", "from": who, "type": "human",
+                               "jwks": {"keys": [jwk]}}})
+
+    def revoke(frm, target):
+        return c.dispatch({"jsonrpc": "2.0", "id": "r",
+                           "method": "participant.revoke_key",
+                           "params": {"workspace": "w", "from": frm,
+                                      "target_uri": target, "kid": target}})
+
+    other = revoke("human:bob", "human:alice")
+    assert other["error"]["code"] == -32011
+
+    own = revoke("human:alice", "human:alice")
+    assert own["result"]["revoked"] is True
 
 
 # ============================================================

--- a/packages/coordinator/src/profiles/security_signed.ts
+++ b/packages/coordinator/src/profiles/security_signed.ts
@@ -46,6 +46,14 @@ export function registerSecuritySigned(coord: Coordinator): void {
     for (const f of ["target_uri", "kid"]) {
       if (!(f in p)) return { error: rpcError(E.PARAMS, `Missing field: ${f}`) };
     }
+    const sender = p.from as string | undefined;
+    if (sender !== p.target_uri) {
+      const caller = sender ? ws.members.get(sender) : undefined;
+      if (!caller || caller.role !== "admin") {
+        return { error: rpcError(E.NOT_AUTHORISED,
+          "Revoking another member's key requires the admin role") };
+      }
+    }
     const member = ws.members.get(p.target_uri as string);
     if (!member) return { error: rpcError(E.SIG_KEY_NOT_FOUND, `Unknown target: ${p.target_uri}`) };
     const key = member.keys.find(k => k.kid === p.kid);

--- a/packages/coordinator/tests/identity_and_signed.test.ts
+++ b/packages/coordinator/tests/identity_and_signed.test.ts
@@ -122,10 +122,29 @@ test("participant.revoke_key marks the key revoked", () => {
   c.dispatch({ jsonrpc: "2.0", id: "2", method: "participant.join",
     params: { workspace: "wsp_rv", from: "human:alice", type: "human", role: "owner",
               jwks: { keys: [k.jwk] }}});
+  c.dispatch({ jsonrpc: "2.0", id: "2a", method: "participant.join",
+    params: { workspace: "wsp_rv", from: "human:admin", type: "human", role: "admin" }});
   const r = c.dispatch({ jsonrpc: "2.0", id: "3", method: "participant.revoke_key",
     params: { workspace: "wsp_rv", from: "human:admin",
               target_uri: "human:alice", kid: k.jwk.kid, reason: "test" }});
   assert.ok((r.result as { revoked: boolean }).revoked);
+});
+
+test("participant.revoke_key requires self or admin", () => {
+  const c = new Coordinator({});
+  c.dispatch({ jsonrpc: "2.0", id: "1", method: "workspace.create",
+    params: { workspace: "w" }});
+  for (const who of ["human:alice", "human:bob"]) {
+    const g = genKeypair();
+    c.dispatch({ jsonrpc: "2.0", id: "j", method: "participant.join",
+      params: { workspace: "w", from: who, type: "human", jwks: { keys: [{ ...g.jwk, kid: who }] }}});
+  }
+  const revoke = (from: string, target: string) =>
+    c.dispatch({ jsonrpc: "2.0", id: "r", method: "participant.revoke_key",
+      params: { workspace: "w", from, target_uri: target, kid: target }});
+
+  assert.equal((revoke("human:bob", "human:alice").error as { code: number }).code, -32011);
+  assert.ok((revoke("human:alice", "human:alice").result as { revoked: boolean }).revoked);
 });
 
 // ============================================================


### PR DESCRIPTION
Closes #33.

`participant.revoke_key` keyed off `target_uri` and never read `from`, so any caller
could revoke any member's key (and under the default unsigned mode, anonymously).

The handler now requires the caller to be authorised: `from` may revoke its **own** key
(`from == target_uri`), or a member with the **admin** role may revoke another's;
anything else returns `-32011` (`NOT_AUTHORISED`). Under `require_signatures` the general
path already verifies `from` is a member whose key signed the envelope, so the unsigned
"anyone revokes anyone" case is the transport's job; this closes the residual gap that any
member could revoke any key.

Kept minimal per the discussion: this is the built-in floor; a richer key-authority model
belongs in the identity layer, not `security-signed`.

The existing revoke tests were revoking with an unjoined, unsigned admin — they now join
that admin with the `admin` role. New regression test: a non-admin member revoking
another's key is rejected `-32011`, self-revocation succeeds (fails on current `main`).
Python 207/207, TS 147/147, typecheck clean.
