### PR TITLE
Fail step-up closed for OIDC actors and enforce min_acr

### DIFF
--- a/packages/coordinator-py/chap_coordinator/coordinator.py
+++ b/packages/coordinator-py/chap_coordinator/coordinator.py
@@ -608,8 +608,17 @@ class Coordinator:
         if not ws:
             return None
         member = ws.members.get(sender)
-        if not member or member.oidc_auth_time is None:
+        if member is None:
             return None
+        # Step-up applies to OIDC actors -- humans, or any member with an OIDC
+        # binding. Agents and services authenticate out of band (SPIFFE/X.509),
+        # so they are not held to an auth_time window here.
+        if member.type != "human" and member.oidc_sub is None:
+            return None
+        if member.oidc_auth_time is None:
+            return rpc_error(E.OIDC_STEP_UP_REQUIRED,
+                             "Step-up authentication required",
+                             {"window_sec": ws.step_up_window_sec})
         now_unix = int(_dt.datetime.now(_dt.timezone.utc).timestamp())
         age = now_unix - member.oidc_auth_time
         if age > ws.step_up_window_sec:
@@ -617,6 +626,10 @@ class Coordinator:
                              "Step-up authentication required",
                              {"window_sec": ws.step_up_window_sec,
                               "age_sec": age})
+        if ws.min_acr is not None and member.oidc_acr != ws.min_acr:
+            return rpc_error(E.OIDC_STEP_UP_REQUIRED,
+                             "Step-up required: acr below the workspace minimum",
+                             {"required_acr": ws.min_acr, "acr": member.oidc_acr})
         return None
 
     # ============================================================
@@ -687,6 +700,7 @@ class Coordinator:
             mode_ceiling=p.get("mode_ceiling") or "production",
             routing_policy_uri=p.get("routing_policy_uri"),
             step_up_window_sec=int(p.get("step_up_window_sec") or 300),
+            min_acr=p.get("min_acr"),
         )
         if "audit-scitt/1.0" in profiles or self.options.enable_chain:
             ws.chain_enabled = True
@@ -770,6 +784,7 @@ class Coordinator:
             at = claims.get("auth_time")
             if isinstance(at, (int, float)):
                 member.oidc_auth_time = int(at)
+            member.oidc_acr = claims.get("acr")
             # Pin the cnf.jwk if present (RFC 7800)
             cnf = claims.get("cnf") or {}
             cnf_jwk = cnf.get("jwk") if isinstance(cnf, dict) else None

--- a/packages/coordinator-py/chap_coordinator/types.py
+++ b/packages/coordinator-py/chap_coordinator/types.py
@@ -90,6 +90,7 @@ class Member:
     # OIDC binding (set when identity-oidc/1.0 is in use)
     oidc_sub: str | None = None
     oidc_auth_time: int | None = None
+    oidc_acr: str | None = None
     # VC binding (set when identity-vc/1.0 is in use)
     vc_holder: str | None = None  # e.g. did:example:alice
 
@@ -566,6 +567,7 @@ class Workspace:
     mode_ceiling: Mode = "production"
     routing_policy_uri: str | None = None
     step_up_window_sec: int = 300  # identity-oidc/1.0 step-up window
+    min_acr: str | None = None  # required OIDC acr for privileged methods
     members: dict[str, Member] = field(default_factory=dict)
     tasks: dict[str, Task] = field(default_factory=dict)
     overrides: dict[str, OverrideArtefact] = field(default_factory=dict)

--- a/packages/coordinator-py/tests/test_step_up.py
+++ b/packages/coordinator-py/tests/test_step_up.py
@@ -1,0 +1,61 @@
+"""
+Regression: step-up must fail closed for OIDC actors. A human (or any member with
+an OIDC binding) invoking a privileged method under enforce_step_up must present a
+fresh auth_time and, when the workspace sets min_acr, a matching acr. Agents and
+services without an OIDC binding authenticate out of band and stay exempt.
+"""
+from __future__ import annotations
+
+import time
+
+from chap_coordinator import Coordinator, CoordinatorOptions
+
+
+def _privileged(c, sender):
+    return c.dispatch({"jsonrpc": "2.0", "id": "p",
+                       "method": "workspace.set_profiles",
+                       "params": {"workspace": "w", "from": sender,
+                                  "profiles": ["core/1.0", "review/1.0"]}})
+
+
+def test_step_up_denies_human_without_fresh_auth():
+    c = Coordinator(CoordinatorOptions(enforce_step_up=True))
+    c.dispatch({"jsonrpc": "2.0", "id": "1", "method": "workspace.create",
+                "params": {"workspace": "w"}})
+    c.dispatch({"jsonrpc": "2.0", "id": "2", "method": "participant.join",
+                "params": {"workspace": "w", "from": "human:alice", "type": "human"}})
+    r = _privileged(c, "human:alice")
+    assert r["error"]["code"] == -32402
+
+
+def test_step_up_exempts_agent_without_oidc():
+    c = Coordinator(CoordinatorOptions(enforce_step_up=True))
+    c.dispatch({"jsonrpc": "2.0", "id": "1", "method": "workspace.create",
+                "params": {"workspace": "w"}})
+    c.dispatch({"jsonrpc": "2.0", "id": "2", "method": "participant.join",
+                "params": {"workspace": "w", "from": "agent:bot", "type": "agent"}})
+    r = _privileged(c, "agent:bot")
+    assert "error" not in r or r["error"]["code"] != -32402
+
+
+def test_step_up_enforces_min_acr():
+    fresh = int(time.time())
+
+    def verify(token):
+        return {"sub": "u", "auth_time": fresh, "acr": token}
+
+    c = Coordinator(CoordinatorOptions(enforce_step_up=True, verify_oidc_token=verify))
+    c.dispatch({"jsonrpc": "2.0", "id": "1", "method": "workspace.create",
+                "params": {"workspace": "w", "min_acr": "mfa"}})
+    c.dispatch({"jsonrpc": "2.0", "id": "2", "method": "participant.join",
+                "params": {"workspace": "w", "from": "human:alice", "type": "human",
+                           "oidc_token": "pwd"}})
+    c.dispatch({"jsonrpc": "2.0", "id": "3", "method": "participant.join",
+                "params": {"workspace": "w", "from": "human:bob", "type": "human",
+                           "oidc_token": "mfa"}})
+
+    below = _privileged(c, "human:alice")
+    assert below["error"]["code"] == -32402
+
+    ok = _privileged(c, "human:bob")
+    assert "error" not in ok or ok["error"]["code"] != -32402

--- a/packages/coordinator/src/coordinator.ts
+++ b/packages/coordinator/src/coordinator.ts
@@ -340,6 +340,7 @@ export class Coordinator {
         mode_ceiling: ws.mode_ceiling,
         routing_policy_uri: ws.routing_policy_uri,
         step_up_window_sec: ws.step_up_window_sec,
+        min_acr:         ws.min_acr,
         members:         Array.from(ws.members.values()),
         tasks:           Array.from(ws.tasks.values()),
         overrides:       Array.from(ws.overrides.values()),
@@ -371,6 +372,7 @@ export class Coordinator {
         mode_ceiling: (w.mode_ceiling as Mode) ?? "production",
         routing_policy_uri: w.routing_policy_uri as string | undefined,
         step_up_window_sec: (w.step_up_window_sec as number) ?? 300,
+        min_acr: w.min_acr as string | undefined,
         members: new Map(),
         tasks: new Map(),
         overrides: new Map(),
@@ -611,12 +613,26 @@ export class Coordinator {
     const ws = this.workspaces.get(wsId);
     if (!ws) return null;
     const member = ws.members.get(sender);
-    if (!member || member.oidc_auth_time === undefined) return null;
+    if (!member) return null;
+    // Step-up applies to OIDC actors -- humans, or any member with an OIDC
+    // binding. Agents and services authenticate out of band (SPIFFE/X.509),
+    // so they are not held to an auth_time window here.
+    if (member.type !== "human" && member.oidc_sub === undefined) return null;
+    if (member.oidc_auth_time === undefined) {
+      return rpcError(E.OIDC_STEP_UP_REQUIRED, "Step-up authentication required", {
+        window_sec: ws.step_up_window_sec,
+      });
+    }
     const nowSec = Math.floor(Date.now() / 1000);
     const age = nowSec - member.oidc_auth_time;
     if (age > ws.step_up_window_sec) {
       return rpcError(E.OIDC_STEP_UP_REQUIRED, "Step-up authentication required", {
         window_sec: ws.step_up_window_sec, age_sec: age,
+      });
+    }
+    if (ws.min_acr !== undefined && member.oidc_acr !== ws.min_acr) {
+      return rpcError(E.OIDC_STEP_UP_REQUIRED, "Step-up required: acr below the workspace minimum", {
+        required_acr: ws.min_acr, acr: member.oidc_acr,
       });
     }
     return null;
@@ -674,6 +690,7 @@ export class Coordinator {
       mode_ceiling: (p.mode_ceiling as Mode) ?? "production",
       routing_policy_uri: p.routing_policy_uri as string | undefined,
       step_up_window_sec: typeof p.step_up_window_sec === "number" ? p.step_up_window_sec : 300,
+      min_acr: p.min_acr as string | undefined,
       members: new Map(),
       tasks: new Map(),
       overrides: new Map(),
@@ -758,6 +775,7 @@ export class Coordinator {
       member.oidc_sub = claims.sub as string | undefined;
       const at = claims.auth_time;
       if (typeof at === "number") member.oidc_auth_time = at;
+      member.oidc_acr = claims.acr as string | undefined;
       const cnf = claims.cnf as Record<string, unknown> | undefined;
       const cnfJwk = cnf?.jwk as Record<string, unknown> | undefined;
       if (cnfJwk && typeof cnfJwk.kid === "string") {
@@ -792,6 +810,7 @@ export class Coordinator {
     if (existing) {
       if (member.oidc_sub !== undefined) existing.oidc_sub = member.oidc_sub;
       if (member.oidc_auth_time !== undefined) existing.oidc_auth_time = member.oidc_auth_time;
+      if (member.oidc_acr !== undefined) existing.oidc_acr = member.oidc_acr;
       if (member.vc_holder !== undefined) existing.vc_holder = member.vc_holder;
       for (const k of attested) {
         if (!existing.keys.some(x => x.kid === k.kid)) existing.keys.push(k);

--- a/packages/coordinator/src/types.ts
+++ b/packages/coordinator/src/types.ts
@@ -82,6 +82,7 @@ export interface Member {
   paused:        boolean;         // control.pause scope=participant
   oidc_sub?:     string;
   oidc_auth_time?: number;        // unix seconds
+  oidc_acr?:     string;
   vc_holder?:    string;
 }
 
@@ -338,6 +339,7 @@ export interface Workspace {
   mode_ceiling: Mode;
   routing_policy_uri?: string;
   step_up_window_sec: number;
+  min_acr?: string;
   members:         Map<ParticipantUri, Member>;
   tasks:           Map<TaskId, Task>;
   overrides:       Map<ArtefactId, OverrideArtefact>;

--- a/packages/coordinator/tests/step_up.test.ts
+++ b/packages/coordinator/tests/step_up.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Regression: step-up fails closed for OIDC actors (humans / members with an OIDC
+ * binding) and enforces min_acr; agents and services without an OIDC binding are
+ * exempt. Mirrors packages/coordinator-py/tests/test_step_up.py.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { Coordinator } from "../src/index.js";
+
+function privileged(c: Coordinator, from: string) {
+  return c.dispatch({ jsonrpc: "2.0", id: "p", method: "workspace.set_profiles",
+    params: { workspace: "w", from, profiles: ["core/1.0", "review/1.0"] }});
+}
+
+test("step-up denies an OIDC human without fresh auth", () => {
+  const c = new Coordinator({ enforceStepUp: true });
+  c.dispatch({ jsonrpc: "2.0", id: "1", method: "workspace.create", params: { workspace: "w" }});
+  c.dispatch({ jsonrpc: "2.0", id: "2", method: "participant.join",
+    params: { workspace: "w", from: "human:alice", type: "human" }});
+  assert.equal(privileged(c, "human:alice").error?.code, -32402);
+});
+
+test("step-up exempts a non-OIDC agent", () => {
+  const c = new Coordinator({ enforceStepUp: true });
+  c.dispatch({ jsonrpc: "2.0", id: "1", method: "workspace.create", params: { workspace: "w" }});
+  c.dispatch({ jsonrpc: "2.0", id: "2", method: "participant.join",
+    params: { workspace: "w", from: "agent:bot", type: "agent" }});
+  assert.notEqual(privileged(c, "agent:bot").error?.code, -32402);
+});
+
+test("step-up enforces min_acr", () => {
+  const fresh = Math.floor(Date.now() / 1000);
+  const c = new Coordinator({ enforceStepUp: true,
+    verifyOidcToken: (t: string) => ({ sub: "u", auth_time: fresh, acr: t }) });
+  c.dispatch({ jsonrpc: "2.0", id: "1", method: "workspace.create",
+    params: { workspace: "w", min_acr: "mfa" }});
+  c.dispatch({ jsonrpc: "2.0", id: "2", method: "participant.join",
+    params: { workspace: "w", from: "human:alice", type: "human", oidc_token: "pwd" }});
+  c.dispatch({ jsonrpc: "2.0", id: "3", method: "participant.join",
+    params: { workspace: "w", from: "human:bob", type: "human", oidc_token: "mfa" }});
+  assert.equal(privileged(c, "human:alice").error?.code, -32402);
+  assert.notEqual(privileged(c, "human:bob").error?.code, -32402);
+});


### PR DESCRIPTION
Closes #45.

`_check_step_up` returned "allow" whenever `oidc_auth_time` was `None`, so under
`enforce_step_up` a human (or any OIDC-bound member) sailed through every privileged
method, and `acr` was never read — both contradict SECURITY.md S4.

Fix, scoped to the mixed-actor model:
- **Fail closed, but only for OIDC actors** — a member of type `human`, or any member
  with an `oidc_sub` binding. For them, a missing or stale `auth_time` under
  `enforce_step_up` is denied `-32402`. Agents and services without an OIDC binding
  authenticate out of band (SPIFFE/X.509) and stay exempt, so this doesn't lock them out
  of `control.*` / key methods.
- **`acr`** — captured at join; the workspace may set `min_acr`, and an OIDC actor's `acr`
  must then equal it. `acr` values are opaque and deployment-defined with no universal
  ordering, so `min_acr` is enforced as the **required** acr (exact match); an ordered or
  set-based acr policy belongs in the identity layer, not here.

Only bites under `enforce_step_up` (default off), so no change to existing deployments —
this is CHAP consuming the OIDC assertions it already receives, not new identity machinery.
`oidc_acr` / `min_acr` round-trip through the store.

Regression tests (both refs): an OIDC human without fresh auth is denied `-32402`; a
non-OIDC agent is allowed; `min_acr` below the required value is denied. The deny and acr
tests fail on current `main`. Python 210/210, TS 150/150, typecheck clean, adapters 75/75.
