### PR TITLE
Require membership for lifecycle mutations, gate set_profiles by role

### DIFF
--- a/packages/coordinator-py/chap_coordinator/coordinator.py
+++ b/packages/coordinator-py/chap_coordinator/coordinator.py
@@ -96,6 +96,11 @@ class CoordinatorOptions:
     enforce_step_up: bool = False
     """Reject privileged methods when OIDC auth_time is stale."""
 
+    require_read_membership: bool = False
+    """Require audit.read / workspace.describe callers to be members. Off by
+    default: reads are transport-delegated. Enable for multi-tenant or
+    directly-exposed deployments."""
+
     on_audit: AuditListener | None = None
     """Called after every successfully recorded audit entry."""
 
@@ -701,6 +706,10 @@ class Coordinator:
         ws = self.workspaces.get(p["workspace"])
         if not ws:
             return {"error": rpc_error(E.PARAMS, f"Unknown workspace: {p['workspace']}")}
+        if self.options.require_read_membership:
+            not_member = self._require_member(ws, p.get("from"))
+            if not_member:
+                return not_member
         out: dict[str, Any] = {
             "id": ws.id,
             "created": ws.created,
@@ -720,12 +729,19 @@ class Coordinator:
         return {"result": out}
 
     def _op_workspace_set_profiles(self, p: dict) -> dict:
-        miss = _missing(p, ["workspace", "profiles"])
+        miss = _missing(p, ["workspace", "from", "profiles"])
         if miss:
             return {"error": rpc_error(E.PARAMS, f"Missing field: {miss}")}
         ws = self.workspaces.get(p["workspace"])
         if not ws:
             return {"error": rpc_error(E.PARAMS, "Unknown workspace")}
+        not_member = self._require_member(ws, p["from"])
+        if not_member:
+            return not_member
+        if ws.members[p["from"]].role != "admin":
+            return {"error": rpc_error(
+                E.NOT_AUTHORISED,
+                "workspace.set_profiles requires the admin role")}
         new_profiles = list(p["profiles"])
         if not any(prof.startswith("core/") for prof in new_profiles):
             new_profiles.append("core/1.0")
@@ -819,6 +835,10 @@ class Coordinator:
         return {"result": {"joined": True, "as": uri}}
 
     def _op_participant_leave(self, p: dict) -> dict:
+        # Self-removal: pops the caller's own `from`. Under require_signatures
+        # the signature binds `from`, so a member can only remove itself;
+        # evicting another member is an admin operation, not this. Unsigned, a
+        # spoofed `from` is the transport's responsibility.
         ws = self.workspaces.get(p.get("workspace", ""))
         if not ws:
             return {"error": rpc_error(E.PARAMS, "Unknown workspace")}
@@ -832,6 +852,9 @@ class Coordinator:
         ws = self.workspaces.get(p["workspace"])
         if not ws:
             return {"error": rpc_error(E.PARAMS, "Unknown workspace")}
+        not_member = self._require_member(ws, p.get("from"))
+        if not_member:
+            return not_member
         assignee = p.get("assignee") or p.get("to")
         if not assignee or assignee not in ws.members:
             return {"error": rpc_error(E.PARAMS, "Assignee not in workspace")}
@@ -879,6 +902,9 @@ class Coordinator:
         ws = self.workspaces.get(p.get("workspace", ""))
         if not ws:
             return {"error": rpc_error(E.PARAMS, "Unknown workspace")}
+        not_member = self._require_member(ws, p.get("from"))
+        if not_member:
+            return not_member
         task = ws.tasks.get(p.get("task_id", ""))
         if not task:
             return {"error": rpc_error(E.PARAMS, "Unknown task")}
@@ -937,6 +963,10 @@ class Coordinator:
         ws = self.workspaces.get(p.get("workspace", ""))
         if not ws:
             return {"error": rpc_error(E.PARAMS, "Unknown workspace")}
+        if self.options.require_read_membership:
+            not_member = self._require_member(ws, p.get("from"))
+            if not_member:
+                return not_member
         rng = p.get("range") or {}
         flt = p.get("filter") or {}
         from_seq = int(rng.get("from_seq", 0))

--- a/packages/coordinator-py/tests/test_membership_floor.py
+++ b/packages/coordinator-py/tests/test_membership_floor.py
@@ -1,0 +1,78 @@
+"""
+Regression: task.create / task.update require the caller to be a workspace
+member; workspace.set_profiles requires the admin role; audit.read and
+workspace.describe are transport-delegated by default but can be gated with
+require_read_membership.
+"""
+from __future__ import annotations
+
+from chap_coordinator import Coordinator, CoordinatorOptions
+
+
+def _member_ws(**opts):
+    c = Coordinator(CoordinatorOptions(**opts))
+    c.dispatch({"jsonrpc": "2.0", "id": "1", "method": "workspace.create",
+                "params": {"workspace": "w", "profiles": ["core/1.0"]}})
+    c.dispatch({"jsonrpc": "2.0", "id": "2", "method": "participant.join",
+                "params": {"workspace": "w", "from": "agent:bot", "type": "agent"}})
+    return c
+
+
+def test_task_create_requires_membership():
+    c = _member_ws()
+    r = c.dispatch({"jsonrpc": "2.0", "id": "t", "method": "task.create",
+                    "params": {"workspace": "w", "from": "human:stranger",
+                               "kind": "k", "input": {}, "assignee": "agent:bot"}})
+    assert r["error"]["code"] == -32011
+
+
+def test_task_update_requires_membership():
+    c = _member_ws()
+    tc = c.dispatch({"jsonrpc": "2.0", "id": "c", "method": "task.create",
+                     "params": {"workspace": "w", "from": "agent:bot",
+                                "kind": "k", "input": {}, "assignee": "agent:bot"}})
+    tid = tc["result"]["task_id"]
+    r = c.dispatch({"jsonrpc": "2.0", "id": "u", "method": "task.update",
+                    "params": {"workspace": "w", "from": "human:stranger",
+                               "task_id": tid, "state": "in_progress"}})
+    assert r["error"]["code"] == -32011
+
+
+def test_set_profiles_requires_admin():
+    c = Coordinator(CoordinatorOptions())
+    c.dispatch({"jsonrpc": "2.0", "id": "1", "method": "workspace.create",
+                "params": {"workspace": "w"}})
+    c.dispatch({"jsonrpc": "2.0", "id": "2", "method": "participant.join",
+                "params": {"workspace": "w", "from": "human:alice", "type": "human"}})
+    c.dispatch({"jsonrpc": "2.0", "id": "3", "method": "participant.join",
+                "params": {"workspace": "w", "from": "human:admin", "type": "human",
+                           "role": "admin"}})
+
+    def set_profiles(sender):
+        return c.dispatch({"jsonrpc": "2.0", "id": "s", "method": "workspace.set_profiles",
+                           "params": {"workspace": "w", "from": sender,
+                                      "profiles": ["core/1.0", "review/1.0"]}})
+
+    assert set_profiles("human:alice")["error"]["code"] == -32011
+    assert "result" in set_profiles("human:admin")
+
+
+def test_reads_transport_delegated_by_default():
+    c = _member_ws()
+    assert "result" in c.dispatch({"jsonrpc": "2.0", "id": "r", "method": "audit.read",
+                                   "params": {"workspace": "w"}})
+    assert "result" in c.dispatch({"jsonrpc": "2.0", "id": "d", "method": "workspace.describe",
+                                   "params": {"workspace": "w"}})
+
+
+def test_reads_gateable_with_require_read_membership():
+    c = _member_ws(require_read_membership=True)
+
+    def read(sender):
+        p = {"workspace": "w"}
+        if sender is not None:
+            p["from"] = sender
+        return c.dispatch({"jsonrpc": "2.0", "id": "r", "method": "audit.read", "params": p})
+
+    assert read("human:stranger")["error"]["code"] == -32011
+    assert "result" in read("agent:bot")

--- a/packages/coordinator-py/tests/test_verify_chain_unchained.py
+++ b/packages/coordinator-py/tests/test_verify_chain_unchained.py
@@ -31,7 +31,7 @@ def test_chain_enabled_midlife_verifies_from_first_chained_entry():
     c = Coordinator(CoordinatorOptions(deterministic_ids=True))
     s = _send(c)
     s("workspace.create", workspace="w", profiles=["core/1.0"])
-    s("participant.join", workspace="w", **{"from": "human:a"}, type="human")
+    s("participant.join", workspace="w", **{"from": "human:a"}, type="human", role="admin")
     s("participant.join", workspace="w", **{"from": "agent:b"}, type="agent")
     s("task.create", workspace="w", **{"from": "human:a"}, kind="k", input={}, assignee="agent:b")
     s("workspace.set_profiles", workspace="w", **{"from": "human:a"},

--- a/packages/coordinator/src/coordinator.ts
+++ b/packages/coordinator/src/coordinator.ts
@@ -95,6 +95,7 @@ export interface CoordinatorOptions {
   enableChain?: boolean;
   requireSignatures?: boolean;
   enforceStepUp?: boolean;
+  requireReadMembership?: boolean;
   onAudit?: AuditListener;
   onAutoEscalate?: (task: Task, to: ParticipantUri) => void;
   verifyOidcToken?: TokenVerifier;
@@ -695,6 +696,10 @@ export class Coordinator {
     if (miss) return { error: rpcError(E.PARAMS, `Missing field: ${miss}`) };
     const ws = this.workspaces.get(p.workspace as string);
     if (!ws) return { error: rpcError(E.PARAMS, `Unknown workspace: ${p.workspace}`) };
+    if (this.options.requireReadMembership) {
+      const notMember = this.requireMember(ws, p.from);
+      if (notMember) return notMember;
+    }
     return { result: {
       id: ws.id,
       created: ws.created,
@@ -713,10 +718,15 @@ export class Coordinator {
   }
 
   private opWorkspaceSetProfiles(p: Record<string, unknown>): ReturnType<Handler> {
-    const miss = missing(p, ["workspace", "profiles"]);
+    const miss = missing(p, ["workspace", "from", "profiles"]);
     if (miss) return { error: rpcError(E.PARAMS, `Missing field: ${miss}`) };
     const ws = this.workspaces.get(p.workspace as string);
     if (!ws) return { error: rpcError(E.PARAMS, "Unknown workspace") };
+    const notMember = this.requireMember(ws, p.from);
+    if (notMember) return notMember;
+    if (ws.members.get(p.from as string)!.role !== "admin") {
+      return { error: rpcError(E.NOT_AUTHORISED, "workspace.set_profiles requires the admin role") };
+    }
     const newProfiles = [...(p.profiles as string[])];
     if (!newProfiles.some(pr => pr.startsWith("core/"))) newProfiles.push("core/1.0");
     ws.profiles = newProfiles;
@@ -803,6 +813,10 @@ export class Coordinator {
   }
 
   private opParticipantLeave(p: Record<string, unknown>): ReturnType<Handler> {
+    // Self-removal: deletes the caller's own `from`. Under requireSignatures the
+    // signature binds `from`, so a member can only remove itself; evicting
+    // another member is an admin operation, not this. Unsigned, a spoofed
+    // `from` is the transport's responsibility.
     const ws = this.workspaces.get(p.workspace as string);
     if (!ws) return { error: rpcError(E.PARAMS, "Unknown workspace") };
     ws.members.delete(p.from as string);
@@ -814,6 +828,8 @@ export class Coordinator {
     if (miss) return { error: rpcError(E.PARAMS, `Missing field: ${miss}`) };
     const ws = this.workspaces.get(p.workspace as string);
     if (!ws) return { error: rpcError(E.PARAMS, "Unknown workspace") };
+    const notMember = this.requireMember(ws, p.from);
+    if (notMember) return notMember;
     const assignee = (p.assignee as string) || (p.to as string);
     if (!assignee || !ws.members.has(assignee)) {
       return { error: rpcError(E.PARAMS, "Assignee not in workspace") };
@@ -858,6 +874,8 @@ export class Coordinator {
   private opTaskUpdate(p: Record<string, unknown>): ReturnType<Handler> {
     const ws = this.workspaces.get(p.workspace as string);
     if (!ws) return { error: rpcError(E.PARAMS, "Unknown workspace") };
+    const notMember = this.requireMember(ws, p.from);
+    if (notMember) return notMember;
     const task = ws.tasks.get(p.task_id as string);
     if (!task) return { error: rpcError(E.PARAMS, "Unknown task") };
     const newState = p.state as Task["state"];
@@ -905,6 +923,10 @@ export class Coordinator {
   private opAuditRead(p: Record<string, unknown>): ReturnType<Handler> {
     const ws = this.workspaces.get(p.workspace as string);
     if (!ws) return { error: rpcError(E.PARAMS, "Unknown workspace") };
+    if (this.options.requireReadMembership) {
+      const notMember = this.requireMember(ws, p.from);
+      if (notMember) return notMember;
+    }
     const range = (p.range as { from_seq?: number; to_seq?: number } | undefined) ?? {};
     const filter = (p.filter as { method?: string; from?: string; task_id?: string } | undefined) ?? {};
     const fromSeq = range.from_seq ?? 0;

--- a/packages/coordinator/tests/membership_floor.test.ts
+++ b/packages/coordinator/tests/membership_floor.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Regression: task.create / task.update require membership; set_profiles requires
+ * the admin role; audit.read / workspace.describe are transport-delegated by
+ * default but gated by requireReadMembership. Mirrors test_membership_floor.py.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { Coordinator } from "../src/index.js";
+
+function memberWs(opts = {}) {
+  const c = new Coordinator(opts);
+  c.dispatch({ jsonrpc: "2.0", id: "1", method: "workspace.create",
+    params: { workspace: "w", profiles: ["core/1.0"] }});
+  c.dispatch({ jsonrpc: "2.0", id: "2", method: "participant.join",
+    params: { workspace: "w", from: "agent:bot", type: "agent" }});
+  return c;
+}
+
+test("task.create requires membership", () => {
+  const c = memberWs();
+  const r = c.dispatch({ jsonrpc: "2.0", id: "t", method: "task.create",
+    params: { workspace: "w", from: "human:stranger", kind: "k", input: {}, assignee: "agent:bot" }});
+  assert.equal(r.error?.code, -32011);
+});
+
+test("task.update requires membership", () => {
+  const c = memberWs();
+  const tc = c.dispatch({ jsonrpc: "2.0", id: "c", method: "task.create",
+    params: { workspace: "w", from: "agent:bot", kind: "k", input: {}, assignee: "agent:bot" }});
+  const tid = (tc.result as { task_id: string }).task_id;
+  const r = c.dispatch({ jsonrpc: "2.0", id: "u", method: "task.update",
+    params: { workspace: "w", from: "human:stranger", task_id: tid, state: "in_progress" }});
+  assert.equal(r.error?.code, -32011);
+});
+
+test("set_profiles requires the admin role", () => {
+  const c = new Coordinator({});
+  c.dispatch({ jsonrpc: "2.0", id: "1", method: "workspace.create", params: { workspace: "w" }});
+  c.dispatch({ jsonrpc: "2.0", id: "2", method: "participant.join",
+    params: { workspace: "w", from: "human:alice", type: "human" }});
+  c.dispatch({ jsonrpc: "2.0", id: "3", method: "participant.join",
+    params: { workspace: "w", from: "human:admin", type: "human", role: "admin" }});
+  const setProfiles = (from: string) => c.dispatch({ jsonrpc: "2.0", id: "s",
+    method: "workspace.set_profiles", params: { workspace: "w", from, profiles: ["core/1.0", "review/1.0"] }});
+  assert.equal(setProfiles("human:alice").error?.code, -32011);
+  assert.ok("result" in setProfiles("human:admin"));
+});
+
+test("reads are transport-delegated by default", () => {
+  const c = memberWs();
+  assert.ok("result" in c.dispatch({ jsonrpc: "2.0", id: "r", method: "audit.read", params: { workspace: "w" }}));
+  assert.ok("result" in c.dispatch({ jsonrpc: "2.0", id: "d", method: "workspace.describe", params: { workspace: "w" }}));
+});
+
+test("reads gate on requireReadMembership", () => {
+  const c = memberWs({ requireReadMembership: true });
+  const read = (from?: string) => c.dispatch({ jsonrpc: "2.0", id: "r", method: "audit.read",
+    params: from ? { workspace: "w", from } : { workspace: "w" }});
+  assert.equal(read("human:stranger").error?.code, -32011);
+  assert.ok("result" in read("agent:bot"));
+});

--- a/packages/coordinator/tests/verify_chain_unchained.test.ts
+++ b/packages/coordinator/tests/verify_chain_unchained.test.ts
@@ -28,7 +28,7 @@ test("a chain enabled mid-life verifies from the first chained entry", () => {
   const c = new Coordinator({ deterministicIds: true });
   const s = send(c);
   s("workspace.create", { workspace: "w", profiles: ["core/1.0"] });
-  s("participant.join", { workspace: "w", from: "human:a", type: "human" });
+  s("participant.join", { workspace: "w", from: "human:a", type: "human", role: "admin" });
   s("participant.join", { workspace: "w", from: "agent:b", type: "agent" });
   s("task.create", { workspace: "w", from: "human:a", kind: "k", input: {}, assignee: "agent:b" });
   s("workspace.set_profiles", { workspace: "w", from: "human:a", profiles: ["core/1.0", "audit-scitt/1.0"] });


### PR DESCRIPTION
Closes #44.

Under the two-mode model (under `require_signatures` the coordinator enforces; unsigned
is transport-delegated), four methods were ungated:

- **`task.create` / `task.update`** took `from` at face value — a non-member could create
  or advance tasks, and `task.update`'s `review_requested -> completed` transition let a
  non-member bypass the review gate. Both now call `_require_member`, matching
  `task.complete` / `decide.*` / `escalate.raise`.
- **`workspace.set_profiles`** read no `from` at all. It now requires the caller to be a
  member **with the admin role**, since changing the profile set changes the workspace's
  security posture. Bootstrap-safe: profiles are set at `workspace.create`, so this is only
  later reconfiguration.
- **`audit.read` / `workspace.describe`** are **not** hard-gated — all five adapters read
  with only `{workspace}` and no `from`, so a blanket floor would break them. Instead, an
  opt-in **`require_read_membership`** option (default off) gates them for multi-tenant or
  directly-exposed deployments; reads are transport-delegated by default.
- **`participant.leave`** is self-removal (pops the caller's own `from`); under
  `require_signatures` the signature binds `from`, so a spoofed eviction is only possible
  unsigned, i.e. the transport's job. Documented, no code change.

The two `set_profiles` tests joined `human:a` as a participant; they now join as admin.
Regression tests added for each floor (the three lifecycle/admin ones fail on current
`main`). Python 211/211, TS 151/151, typecheck clean, method catalogue in sync, adapters
75/75.
