### PR TITLE
Add an optional idempotency key to task.create

### DIFF
--- a/packages/coordinator-py/chap_coordinator/coordinator.py
+++ b/packages/coordinator-py/chap_coordinator/coordinator.py
@@ -447,6 +447,20 @@ class Coordinator:
                         E.CONTROL_WORKSPACE_PAUSED,
                         f"Workspace {ws_id} is paused"))
 
+        # task.create idempotency: a repeat carrying a seen idempotency_key
+        # returns the original task rather than creating (or recording) a
+        # duplicate -- safe for at-least-once redelivery.
+        if method == "task.create":
+            key = params.get("idempotency_key")
+            ws_id = params.get("workspace")
+            ws = self.workspaces.get(ws_id) if isinstance(ws_id, str) else None
+            if ws is not None and isinstance(key, str):
+                existing_id = ws.idempotency_keys.get(key)
+                task = ws.tasks.get(existing_id) if existing_id else None
+                if task is not None:
+                    return make_response(env_id, result={
+                        "task_id": existing_id, "state": task.state})
+
         handler = self._handlers.get(method)
         if handler is None:
             return make_response(
@@ -918,6 +932,9 @@ class Coordinator:
             task.review_required = bool(p["review_required"])
 
         ws.tasks[task_id] = task
+        key = p.get("idempotency_key")
+        if isinstance(key, str):
+            ws.idempotency_keys[key] = task_id
         return {"result": {"task_id": task_id, "state": "created"}}
 
     def _op_task_update(self, p: dict) -> dict:

--- a/packages/coordinator-py/chap_coordinator/types.py
+++ b/packages/coordinator-py/chap_coordinator/types.py
@@ -576,6 +576,9 @@ class Workspace:
     handoffs: dict[str, Handoff] = field(default_factory=dict)
     snapshots: dict[str, SnapshotArtefact] = field(default_factory=dict)
     route_decisions: dict[str, RouteDecisionArtefact] = field(default_factory=dict)
+    # task.create idempotency: caller-supplied key -> task_id, so a redelivered
+    # create returns the original task instead of a duplicate.
+    idempotency_keys: dict[str, str] = field(default_factory=dict)
     audit: list[AuditEntry] = field(default_factory=list)
     # Chain state (audit-scitt/1.0 supplementary chain linkage)
     chain_head: str | None = None

--- a/packages/coordinator-py/tests/test_task_idempotency.py
+++ b/packages/coordinator-py/tests/test_task_idempotency.py
@@ -1,0 +1,46 @@
+"""
+Regression: task.create with a repeated idempotency_key returns the original task
+and does not create -- or record -- a duplicate. Makes at-least-once redelivery
+safe for consumers that capture pipeline decisions into a chain.
+"""
+from __future__ import annotations
+
+from chap_coordinator import Coordinator, CoordinatorOptions
+
+
+def _ws():
+    c = Coordinator(CoordinatorOptions())
+    c.dispatch({"jsonrpc": "2.0", "id": "1", "method": "workspace.create",
+                "params": {"workspace": "w"}})
+    c.dispatch({"jsonrpc": "2.0", "id": "2", "method": "participant.join",
+                "params": {"workspace": "w", "from": "agent:bot", "type": "agent"}})
+    return c
+
+
+def _create(c, key=None):
+    params = {"workspace": "w", "from": "agent:bot", "kind": "k",
+              "input": {}, "assignee": "agent:bot"}
+    if key is not None:
+        params["idempotency_key"] = key
+    return c.dispatch({"jsonrpc": "2.0", "id": "t", "method": "task.create",
+                       "params": params})
+
+
+def test_repeated_idempotency_key_returns_same_task_without_duplicate():
+    c = _ws()
+    r1 = _create(c, "cap-42")
+    r2 = _create(c, "cap-42")
+    assert r1["result"]["task_id"] == r2["result"]["task_id"]
+
+    ws = c.workspaces["w"]
+    assert len(ws.tasks) == 1
+    creates = [e for e in ws.audit if e.envelope.get("method") == "task.create"]
+    assert len(creates) == 1
+
+
+def test_no_key_creates_distinct_tasks():
+    c = _ws()
+    a = _create(c)
+    b = _create(c)
+    assert a["result"]["task_id"] != b["result"]["task_id"]
+    assert len(c.workspaces["w"].tasks) == 2

--- a/packages/coordinator/src/coordinator.ts
+++ b/packages/coordinator/src/coordinator.ts
@@ -350,6 +350,7 @@ export class Coordinator {
         handoffs:        Array.from(ws.handoffs.values()),
         snapshots:       Array.from(ws.snapshots.values()),
         route_decisions: Array.from(ws.route_decisions.values()),
+        idempotency_keys: ws.idempotency_keys,
         audit:           ws.audit,
         chain_head:      ws.chain_head,
         chain_enabled:   ws.chain_enabled,
@@ -382,6 +383,7 @@ export class Coordinator {
         handoffs: new Map(),
         snapshots: new Map(),
         route_decisions: new Map(),
+        idempotency_keys: (w.idempotency_keys as Record<string, string>) ?? {},
         audit: (w.audit as AuditEntry[]) ?? [],
         chain_head: w.chain_head as string | undefined,
         chain_enabled: !!w.chain_enabled,
@@ -480,6 +482,20 @@ export class Coordinator {
         if (ws && ws.state === "paused") {
           return reply(envelope, { error: rpcError(E.CONTROL_WORKSPACE_PAUSED, `Workspace ${wsId} is paused`) });
         }
+      }
+    }
+
+    // task.create idempotency: a repeat carrying a seen idempotency_key returns
+    // the original task rather than creating (or recording) a duplicate -- safe
+    // for at-least-once redelivery.
+    if (method === "task.create") {
+      const wsId = params.workspace;
+      const ws = typeof wsId === "string" ? this.workspaces.get(wsId) : undefined;
+      const key = params.idempotency_key;
+      if (ws && typeof key === "string") {
+        const existingId = ws.idempotency_keys[key];
+        const task = existingId ? ws.tasks.get(existingId) : undefined;
+        if (task) return reply(envelope, { result: { task_id: existingId, state: task.state } });
       }
     }
 
@@ -708,6 +724,7 @@ export class Coordinator {
       handoffs: new Map(),
       snapshots: new Map(),
       route_decisions: new Map(),
+      idempotency_keys: {},
       audit: [],
       chain_enabled: chainEnabled,
       chain_head: chainEnabled ? ZERO_HASH : undefined,
@@ -895,6 +912,7 @@ export class Coordinator {
     else if ("review_required" in p) task.review_required = !!p.review_required;
 
     ws.tasks.set(taskId, task);
+    if (typeof p.idempotency_key === "string") ws.idempotency_keys[p.idempotency_key] = taskId;
     return { result: { task_id: taskId, state: "created" } };
   }
 

--- a/packages/coordinator/src/methods.ts
+++ b/packages/coordinator/src/methods.ts
@@ -94,6 +94,7 @@ export interface TaskCreateParams extends WorkspaceParam, ActorParam {
   to?:            ParticipantUri;   // alias for assignee
   routing_hints?: Record<string, unknown>;
   deadline?:      string;
+  idempotency_key?: string;
 }
 export interface TaskCreateResult { task_id: TaskId }
 

--- a/packages/coordinator/src/types.ts
+++ b/packages/coordinator/src/types.ts
@@ -348,6 +348,8 @@ export interface Workspace {
   handoffs:        Map<string, Handoff>;
   snapshots:       Map<ArtefactId, SnapshotArtefact>;
   route_decisions: Map<ArtefactId, RouteDecisionArtefact>;
+  // task.create idempotency: caller-supplied key -> task_id.
+  idempotency_keys: Record<string, TaskId>;
   audit:           AuditEntry[];
   chain_head?:     string;
   chain_enabled:   boolean;

--- a/packages/coordinator/tests/task_idempotency.test.ts
+++ b/packages/coordinator/tests/task_idempotency.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Regression: task.create with a repeated idempotency_key returns the original
+ * task and records no duplicate. Mirrors test_task_idempotency.py.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { Coordinator } from "../src/index.js";
+
+function ws() {
+  const c = new Coordinator({});
+  c.dispatch({ jsonrpc: "2.0", id: "1", method: "workspace.create", params: { workspace: "w" }});
+  c.dispatch({ jsonrpc: "2.0", id: "2", method: "participant.join",
+    params: { workspace: "w", from: "agent:bot", type: "agent" }});
+  return c;
+}
+
+function create(c: Coordinator, key?: string) {
+  const params: Record<string, unknown> = { workspace: "w", from: "agent:bot", kind: "k", input: {}, assignee: "agent:bot" };
+  if (key !== undefined) params.idempotency_key = key;
+  return c.dispatch({ jsonrpc: "2.0", id: "t", method: "task.create", params });
+}
+
+test("repeated idempotency_key returns the same task without a duplicate", () => {
+  const c = ws();
+  const r1 = create(c, "cap-42");
+  const r2 = create(c, "cap-42");
+  assert.equal((r1.result as { task_id: string }).task_id, (r2.result as { task_id: string }).task_id);
+
+  const w = c.workspaces.get("w")!;
+  assert.equal(w.tasks.size, 1);
+  const creates = w.audit.filter(e => e.envelope.method === "task.create");
+  assert.equal(creates.length, 1);
+});
+
+test("no key creates distinct tasks", () => {
+  const c = ws();
+  const a = create(c);
+  const b = create(c);
+  assert.notEqual((a.result as { task_id: string }).task_id, (b.result as { task_id: string }).task_id);
+  assert.equal(c.workspaces.get("w")!.tasks.size, 2);
+});


### PR DESCRIPTION
Implements the optional `task.create` idempotency key suggested when closing #47.

Under an at-least-once transport (e.g. a Pub/Sub push consumer capturing pipeline
decisions), a redelivered `task.create` created a **duplicate task and a duplicate
audit-chain entry**. `task.create` now accepts an optional `idempotency_key`; a repeat
carrying a key that's already been seen returns the **original** task and records nothing
new — the replay is short-circuited in `dispatch` before the handler and the audit write,
so the chain gains no duplicate entry.

It is opt-in: the check only fires when the caller supplies `idempotency_key`, so default
behaviour is unchanged. The `key -> task_id` map is per-workspace and rides the workspace
snapshot (round-trips through the store; older snapshots default to empty).

This is the concrete consumer need behind the eval-harness proposal's at-least-once
capture; it does not reintroduce a protocol-wide replay layer (that stays out of scope per
#47). The separate multi-writer version-CAS gap is tracked in its own issue.

Regression tests (both refs): a repeated key returns the same task_id with exactly one task
and one `task.create` chain entry; no key still creates distinct tasks. The dedup test
fails on current `main`. Python 218/218, TS 158/158, typecheck clean, method catalogue in
sync, adapters 75/75.
