### PR TITLE
CEP-001: bind review decisions to the content they decided on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,44 @@ incremented under the same rules.
 
 ---
 
+## Unreleased
+
+### Review decisions bind the content they decided on (CEP-001)
+
+Reported by Iman Schrock (EMILIA) from a source-pinned CHAP-to-AEB
+interoperability profile, and tracked as #71 and #72. Proposal in
+[`ceps/CEP-001.md`](./ceps/CEP-001.md).
+
+- **Optional `approved_artefact_digest` on `decide.approve`, `decide.reject`
+  and `decide.override`.** SHA-256 over the RFC 8785 (JCS) canonicalisation of
+  the artefact under review, in the `sha256:<hex>` form the evidence chain
+  already uses. The Coordinator verifies it against the artefact under review
+  and refuses a mismatch with `-32074`, recording no decision and changing no
+  state. Absent, behaviour is unchanged.
+
+  The field sits in `params`, so it falls inside whatever the envelope
+  signature covers. A decision then attests content rather than a task
+  reference, and a relying party can verify it without trusting the
+  Coordinator that produced it. Previously a plain approval bound `task_id`
+  and no content, so a consumer could not tell what had been approved.
+
+- **`review.request` on an open review no longer replaces the artefact.**
+  An identical artefact is an amendment: the reviewers in `to` are added to the
+  existing set, decisions already cast are preserved, and the result carries
+  `amended: true`. A different artefact is refused with `-32014`, as is a
+  request that would change the decision rule mid-review.
+
+  Both implementations previously accepted the re-request and overwrote the
+  pending artefact, so a reviewer could decide on content they never saw. Under
+  a quorum rule the effect was worse: the replacement built a fresh review with
+  an empty decision list, discarding decisions already cast while their
+  envelopes remained in the audit log.
+
+- Conformance vectors `rv-09`, `rv-10` and `rv-11`, passing against both
+  reference servers.
+
+---
+
 ## 0.2.9: complete package publish and consolidated 0.2.x hardening
 
 First release with the full set on npm and PyPI: the MCP and A2A coordinators

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -120,7 +120,7 @@ contains:
 | Security           | Threats introduced, mitigated, or unchanged          |
 | Open questions     | Known unresolved items                               |
 
-CEPs are submitted as a pull request to `heps/CEP-NNN.md`. The
+CEPs are submitted as a pull request to `ceps/CEP-NNN.md`. The
 Editor assigns the number and triages.
 
 ### 3.3 Discussion period

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -643,6 +643,8 @@ Transitions are triggered by methods:
 | accepted           | `task.start`                  | in_progress       |
 | in_progress        | `task.complete`               | completed         |
 | in_progress        | `review.request`              | review_requested  |
+| review_requested   | `review.request` (same artefact) | review_requested (reviewer set widened) |
+| review_requested   | `review.request` (different artefact) | refused, -32014 |
 | review_requested   | `decide.approve`              | completed         |
 | review_requested   | `decide.reject`               | (back to in_progress or declined per policy) |
 | review_requested   | `decide.override`             | completed (with override artefact) |

--- a/ceps/CEP-001.md
+++ b/ceps/CEP-001.md
@@ -1,0 +1,133 @@
+# CEP-001: Signature-covered `approved_artefact_digest` on review decisions
+
+| Field              | Value                                                        |
+|--------------------|--------------------------------------------------------------|
+| Status             | Draft                                                        |
+| Author(s)          | Iman Schrock (EMILIA Protocol), Arsalan Shahid (Brightbeam AI) |
+| Tracking issues    | [#71](https://github.com/BrightbeamAI/chap/issues/71), [#72](https://github.com/BrightbeamAI/chap/issues/72) |
+| Reference impl     | Both coordinators in this repository                          |
+
+## Abstract
+
+A review decision names the task it settles but not the content it settled.
+This proposal adds an optional `approved_artefact_digest` to `decide.approve`,
+`decide.reject` and `decide.override`, verified by the Coordinator against the
+artefact under review and refused on mismatch, so that a decision becomes
+self-contained evidence of what a human approved. It also fixes the
+state-machine gap that made the omission exploitable rather than merely
+inconvenient.
+
+## Motivation
+
+Reported by Iman Schrock while building a source-pinned CHAP-to-AEB
+interoperability profile (`emiliaprotocol/emilia-protocol#582`), which consumes
+CHAP decisions as admission evidence at protected execution boundaries.
+
+A signed `decide.override` already carries enough material to map the patched
+artefact to the exact action: the diff is in the envelope and the base is
+chain-bound through `review.request`. A plain `decide.approve` binds `task_id`
+and no content, so their adapter returns INDETERMINATE rather than guess what
+was approved. Returning INDETERMINATE is the correct discipline; the gap is
+CHAP's.
+
+Verifying that analysis surfaced a second consequence of the same gap.
+`review.request` had no guard against re-request, so the pending artefact could
+be replaced while a review was open, and the approve envelope carried nothing
+that would detect the swap. With a quorum rule this is worse than it first
+appears: re-request built a fresh review with an empty decision list, so
+decisions already cast were discarded while their envelopes remained in the
+audit log, leaving what reads as a quorum assembled across two different
+artefacts.
+
+## Specification
+
+### The digest
+
+`decide.approve`, `decide.reject` and `decide.override` accept an optional
+`approved_artefact_digest`: SHA-256 over the RFC 8785 (JCS) canonicalisation of
+the artefact under review, in the `sha256:<hex>` form used throughout the
+evidence chain. It is the existing content-hash construction, not a new one.
+
+When present, the Coordinator computes the digest of the artefact under review
+and compares. On mismatch it refuses with `-32074`
+(`SIG_ARTEFACT_DIGEST_MISMATCH`), records no decision and changes no state. When
+absent, behaviour is unchanged.
+
+The field sits in `params`, so it falls inside whatever the envelope signature
+covers under `security-signed/1.0`. That is the point: the decision attests
+content rather than a task reference, and a relying party can verify it without
+trusting the Coordinator that produced it.
+
+### The state machine
+
+`review.request` on a task already in `review_requested`:
+
+- identical artefact under JCS: an amendment. Reviewers in `to` are added to
+  the existing set, decisions cast so far are preserved, the result carries
+  `"amended": true`.
+- different artefact: refused with `-32014` (`REVIEW_ALREADY_OPEN`), nothing
+  changes.
+- a request that would change the `rule` of an open review: refused with
+  `-32014`.
+
+Allowing the identical-artefact case matters because a review addresses a set
+of reviewers under a rule. Adding a reviewer to a review in flight is
+legitimate; swapping the content underneath it is not. The old behaviour
+conflated the two.
+
+## Compatibility
+
+Additive and optional. An absent digest preserves current behaviour byte for
+byte, so existing clients, adapters and scenarios are unaffected.
+
+The `review.request` guard is a behaviour change, but only for a sequence that
+had no defined transition and that both implementations handled by silently
+overwriting state. No conformance vector, scenario or example exercised it.
+
+Whether the digest should become required under `require_signatures` in a
+future major is deliberately left open. This proposal does not decide it.
+
+## Rationale
+
+The alternative to refusing a re-request is to treat it as a fresh review
+round, resetting eligibility and recording the replacement. That was rejected:
+it keeps substitution legal and relies on every relying party checking a digest
+to notice. Refusing costs nothing, because the revise-and-resubmit path already
+exists through `decide.reject` returning the task to `in_progress`.
+
+Putting the digest in `params` rather than in a new envelope field is what
+makes it signature-covered without touching the envelope schema or the
+signing construction.
+
+## Existing standards
+
+No new primitives. SHA-256 over RFC 8785 JCS is already normative in CHAP's
+evidence chain. Binding content by detached digest is the pattern SCITT and
+COSE practice use for hashed payloads, which keeps a future Signed Statement
+mapping clean.
+
+## Security
+
+Mitigates two things. A decision becomes verifiable against content by a
+relying party that does not trust the Coordinator. And mid-review artefact
+substitution is refused at request time rather than detected later, or not at
+all.
+
+Introduces effectively nothing. A client that computes the wrong digest refuses
+only its own decision. The digest is over canonical form, so there is no
+encoding ambiguity. No key handling changes.
+
+Out of scope by design: this is evidence of a human decision, not of admission
+or execution. Consuming systems remain responsible for their own authority
+model.
+
+## Open questions
+
+- Should the digest become mandatory under `require_signatures` in a future
+  major version?
+- Should `decide.override` also carry an explicit digest of the base artefact,
+  so large artefacts bind compactly and values can be redacted for selective
+  disclosure while the binding stays verifiable? Tracked with the SCITT-thread
+  work.
+- The amendment path currently allows widening `to` only. Should narrowing, or
+  removing a reviewer who has already decided, be defined at all?

--- a/conformance/harness/README.md
+++ b/conformance/harness/README.md
@@ -16,7 +16,7 @@ success.
 - Filter correctness: `audit.read` filters work.
 - Member enforcement: assigning to non-members fails.
 
-**Review profile (optional)**: 8 vectors covering:
+**Review profile (optional)**: 11 vectors covering:
 
 - `review.request` transitions task to `review_requested`.
 - `decide.override` applies the RFC 6902 JSON Patch and produces an

--- a/conformance/harness/harness.ts
+++ b/conformance/harness/harness.ts
@@ -17,6 +17,8 @@
  *   2  invalid arguments or harness error
  */
 
+import { createHash } from "node:crypto";
+
 interface Args {
   url:        string;
   workspace:  string;
@@ -484,6 +486,107 @@ async function runReviewTests(client: HapClient, ws: string): Promise<void> {
     });
     assertEq(result?.state, "completed", "addressed reviewer should still be able to approve");
   });
+
+  // ---- CEP-001: binding a decision to the content it decided on ----
+
+  await test("Review profile", "rv-09", "approve with a matching approved_artefact_digest is accepted", async () => {
+    const artefact = { subject: "digest", body: "bound body", severity: "low" };
+    const { result: t } = await client.call("task.create", {
+      workspace: ws, from: "human:alice@example.org", to: "agent:reviewer-test-bot",
+      ts: new Date().toISOString(), kind: "review_test", assignee: "agent:reviewer-test-bot",
+      input: { test: true },
+    });
+    await client.call("task.update", {
+      workspace: ws, from: "agent:reviewer-test-bot", to: "human:alice@example.org",
+      ts: new Date().toISOString(), task_id: t.task_id, state: "in_progress",
+    });
+    await client.call("review.request", {
+      workspace: ws, from: "agent:reviewer-test-bot", to: ["human:alice@example.org"],
+      ts: new Date().toISOString(), task_id: t.task_id, artefact, rule: "any_one_approves",
+    });
+    const { result } = await client.call("decide.approve", {
+      workspace: ws, from: "human:alice@example.org", to: "service:coordinator@example.org",
+      ts: new Date().toISOString(), task_id: t.task_id,
+      approved_artefact_digest: contentDigest(artefact),
+    });
+    assertEq(result?.state, "completed", "a matching digest should approve as normal");
+  });
+
+  await test("Review profile", "rv-10", "approve with a mismatched digest is refused with -32074 and changes nothing", async () => {
+    const artefact = { subject: "digest", body: "the reviewed body", severity: "low" };
+    const { result: t } = await client.call("task.create", {
+      workspace: ws, from: "human:alice@example.org", to: "agent:reviewer-test-bot",
+      ts: new Date().toISOString(), kind: "review_test", assignee: "agent:reviewer-test-bot",
+      input: { test: true },
+    });
+    await client.call("task.update", {
+      workspace: ws, from: "agent:reviewer-test-bot", to: "human:alice@example.org",
+      ts: new Date().toISOString(), task_id: t.task_id, state: "in_progress",
+    });
+    await client.call("review.request", {
+      workspace: ws, from: "agent:reviewer-test-bot", to: ["human:alice@example.org"],
+      ts: new Date().toISOString(), task_id: t.task_id, artefact, rule: "any_one_approves",
+    });
+    const { error } = await client.call("decide.approve", {
+      workspace: ws, from: "human:alice@example.org", to: "service:coordinator@example.org",
+      ts: new Date().toISOString(), task_id: t.task_id,
+      approved_artefact_digest: contentDigest({ ...artefact, body: "swapped body" }),
+    });
+    assert(error?.code === -32074, `mismatched digest should fail with -32074, got ${JSON.stringify(error)}`);
+    // Nothing recorded: the addressed reviewer can still decide normally.
+    const { result } = await client.call("decide.approve", {
+      workspace: ws, from: "human:alice@example.org", to: "service:coordinator@example.org",
+      ts: new Date().toISOString(), task_id: t.task_id,
+    });
+    assertEq(result?.state, "completed", "a refused decision must leave the review open");
+  });
+
+  await test("Review profile", "rv-11", "review.request with different content on an open review is refused with -32014", async () => {
+    const artefact = { subject: "swap", body: "first body", severity: "low" };
+    const { result: t } = await client.call("task.create", {
+      workspace: ws, from: "human:alice@example.org", to: "agent:reviewer-test-bot",
+      ts: new Date().toISOString(), kind: "review_test", assignee: "agent:reviewer-test-bot",
+      input: { test: true },
+    });
+    await client.call("task.update", {
+      workspace: ws, from: "agent:reviewer-test-bot", to: "human:alice@example.org",
+      ts: new Date().toISOString(), task_id: t.task_id, state: "in_progress",
+    });
+    await client.call("review.request", {
+      workspace: ws, from: "agent:reviewer-test-bot", to: ["human:alice@example.org"],
+      ts: new Date().toISOString(), task_id: t.task_id, artefact, rule: "any_one_approves",
+    });
+    const { error } = await client.call("review.request", {
+      workspace: ws, from: "agent:reviewer-test-bot", to: ["human:alice@example.org"],
+      ts: new Date().toISOString(), task_id: t.task_id,
+      artefact: { ...artefact, body: "substituted body" }, rule: "any_one_approves",
+    });
+    assert(error?.code === -32014, `artefact substitution should fail with -32014, got ${JSON.stringify(error)}`);
+    // The identical artefact is an amendment, not a substitution.
+    const { result } = await client.call("review.request", {
+      workspace: ws, from: "agent:reviewer-test-bot", to: ["human:bystander@example.org"],
+      ts: new Date().toISOString(), task_id: t.task_id, artefact, rule: "any_one_approves",
+    });
+    assertEq(result?.amended, true, "an identical artefact should amend the reviewer set");
+  });
+}
+
+
+/**
+ * The digest construction CEP-001 uses: SHA-256 over RFC 8785 (JCS)
+ * canonicalisation, in CHAP's `sha256:<hex>` wire form. Implemented here so the
+ * harness stays dependency-free and checks the servers rather than a shared
+ * library.
+ */
+function contentDigest(value: unknown): string {
+  return "sha256:" + createHash("sha256").update(jcs(value), "utf-8").digest("hex");
+}
+
+function jcs(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return "[" + value.map(jcs).join(",") + "]";
+  const keys = Object.keys(value as Record<string, unknown>).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  return "{" + keys.map(k => JSON.stringify(k) + ":" + jcs((value as Record<string, unknown>)[k])).join(",") + "}";
 }
 
 // ============================================================

--- a/conformance/test-vectors.md
+++ b/conformance/test-vectors.md
@@ -105,6 +105,25 @@ differs but the bytes look almost right, check (in order):
 
 ---
 
+## 2a. Binding a decision to its content (CEP-001)
+
+Three vectors cover the artefact digest and the open-review guard. They are
+listed here because they are the first vectors that assert on a *refusal* that
+leaves state untouched, which is easy to implement as a refusal that quietly
+does not.
+
+| Vector  | Sends                                                        | Expects                                   |
+|---------|--------------------------------------------------------------|-------------------------------------------|
+| `rv-09` | `decide.approve` with `approved_artefact_digest` equal to `sha256:` + SHA-256 over the JCS form of the artefact under review | approval proceeds, task `completed`       |
+| `rv-10` | the same with a digest of different content                   | `-32074`, no decision recorded, and the review still open so the reviewer can decide afterwards |
+| `rv-11` | `review.request` on an open review carrying different content  | `-32014`; then the identical artefact returns `amended: true` |
+
+`rv-10` deliberately decides again after the refusal. A Coordinator that
+recorded the refused decision, or that closed the review, fails on the second
+call rather than the first.
+
+---
+
 ## 3. Evidence-chain linkage
 
 The chain is a sequence of entries. Each entry carries the chain head

--- a/packages/coordinator-mcp/src/schemas.ts
+++ b/packages/coordinator-mcp/src/schemas.ts
@@ -23,6 +23,8 @@ export interface JsonSchema {
   additionalProperties?: boolean | JsonSchema;
   oneOf?: JsonSchema[];
   default?: unknown;
+  /** JSON Schema `pattern`, used where a string has a fixed wire shape. */
+  pattern?: string;
 }
 
 // Common reusable fragments.
@@ -197,6 +199,11 @@ export const SCHEMAS: Record<string, JsonSchema> = {
     type: "object",
     properties: {
       workspace: WORKSPACE_ID, from: PARTICIPANT_URI, task_id: TASK_ID,
+      approved_artefact_digest: {
+        type: "string",
+        pattern: "^sha256:[0-9a-f]{64}$",
+        description: "Optional. SHA-256 over the JCS canonicalisation of the artefact under review, as `sha256:<hex>`. Binds the decision to the exact content reviewed; refused with -32074 on mismatch.",
+      },
       comment: { type: "string" },
       tags:    { type: "array", items: { type: "string" } },
     },
@@ -207,6 +214,11 @@ export const SCHEMAS: Record<string, JsonSchema> = {
     type: "object",
     properties: {
       workspace: WORKSPACE_ID, from: PARTICIPANT_URI, task_id: TASK_ID,
+      approved_artefact_digest: {
+        type: "string",
+        pattern: "^sha256:[0-9a-f]{64}$",
+        description: "Optional. SHA-256 over the JCS canonicalisation of the artefact under review, as `sha256:<hex>`. Binds the decision to the exact content reviewed; refused with -32074 on mismatch.",
+      },
       comment: { type: "string" },
       tags:    { type: "array", items: { type: "string" } },
       request_revision: { type: "boolean", description: "If true, task returns to in_progress instead of declined." },
@@ -217,6 +229,11 @@ export const SCHEMAS: Record<string, JsonSchema> = {
   "chap.decide.override": {
     type: "object",
     properties: {
+      approved_artefact_digest: {
+        type: "string",
+        pattern: "^sha256:[0-9a-f]{64}$",
+        description: "Optional. SHA-256 over the JCS canonicalisation of the artefact under review, as `sha256:<hex>`. Binds the decision to the exact content reviewed; refused with -32074 on mismatch.",
+      },
       workspace: WORKSPACE_ID, from: PARTICIPANT_URI, task_id: TASK_ID,
       diff: {
         type: "array",

--- a/packages/coordinator-py/chap_coordinator/coordinator.py
+++ b/packages/coordinator-py/chap_coordinator/coordinator.py
@@ -27,7 +27,7 @@ import datetime as _dt
 from dataclasses import dataclass, field
 from typing import Any, Callable
 
-from .canonical import ZERO_HASH, canonicalize, sha256_hex
+from .canonical import ZERO_HASH, canonicalize, content_hash, sha256_hex
 from .ids import IdFactory
 from .jsonrpc import E, is_valid_envelope, make_response, rpc_error
 from .patch import PatchError, apply_json_patch
@@ -1047,12 +1047,48 @@ class Coordinator:
         if not reviewers:
             return {"error": rpc_error(E.PARAMS, "review.request needs 'to'")}
         now = self.now_iso()
+        rule = p.get("rule") or "any_one_approves"
+
+        # A review already open on this task. Replacing the artefact underneath
+        # it would let a reviewer decide on content they never saw, and would
+        # discard decisions already cast while their envelopes remain in the
+        # audit log, so a quorum could appear to have been assembled across two
+        # different artefacts. Re-requesting the *same* artefact is a different
+        # thing: it widens the reviewer set on an open review, which is
+        # legitimate and preserves what has been decided so far.
+        if task.state == "review_requested" and task.review is not None:
+            if content_hash(task.pending_artefact) != content_hash(p["artefact"]):
+                return {"error": rpc_error(
+                    E.REVIEW_ALREADY_OPEN,
+                    "A review is already open on this task with different content. "
+                    "Decide, abstain, escalate or cancel it before requesting "
+                    "review of a new artefact.",
+                )}
+            if rule != task.review.rule:
+                return {"error": rpc_error(
+                    E.REVIEW_ALREADY_OPEN,
+                    f"Cannot change the decision rule of an open review "
+                    f"(currently {task.review.rule})",
+                )}
+            for r in reviewers:
+                if r not in task.review.requested_to:
+                    task.review.requested_to.append(r)
+            if p.get("deadline") is not None:
+                task.review.deadline = p["deadline"]
+            task.updated_at = now
+            return {"result": {
+                "state": "review_requested",
+                "review_id": task.id,
+                "amended": True,
+                "requested_to": list(task.review.requested_to),
+            }}
+
         task.state = "review_requested"
         task.updated_at = now
         task.review = ReviewState(
             requested_at=now,
             requested_to=list(reviewers),
-            rule=p.get("rule") or "any_one_approves",
+            rule=rule,
             deadline=p.get("deadline"),
         )
         task.history.append(TaskHistoryEntry(
@@ -1060,6 +1096,36 @@ class Coordinator:
         ))
         task.pending_artefact = p["artefact"]
         return {"result": {"state": "review_requested", "review_id": task.id}}
+
+    def _check_artefact_digest(self, p: dict, task: "Task") -> "dict | None":
+        """Verify an optional ``approved_artefact_digest`` (review/1.0 S3.2).
+
+        The digest sits in params, so it is inside whatever the envelope
+        signature covers: the decision then attests the content the reviewer
+        saw rather than a task reference, and a relying party can check it
+        without trusting the Coordinator that produced it. Absent, behaviour is
+        exactly as before.
+
+        On mismatch nothing is recorded and no state changes, so a client that
+        computes the wrong digest refuses only its own decision.
+        """
+        declared = p.get("approved_artefact_digest")
+        if declared is None:
+            return None
+        if not isinstance(declared, str):
+            return {"error": rpc_error(
+                E.PARAMS, "approved_artefact_digest must be a string")}
+        if task.pending_artefact is None:
+            return {"error": rpc_error(
+                E.PARAMS, "No artefact under review to bind a digest to")}
+        actual = content_hash(task.pending_artefact)
+        if declared != actual:
+            return {"error": rpc_error(
+                E.SIG_ARTEFACT_DIGEST_MISMATCH,
+                "approved_artefact_digest does not match the artefact under review",
+                {"declared": declared, "actual": actual},
+            )}
+        return None
 
     def _op_decide(self, p: dict, kind: str) -> dict:
         miss = _missing(p, ["workspace", "from", "task_id"])
@@ -1084,6 +1150,9 @@ class Coordinator:
         not_reviewer = self._require_reviewer(task, p.get("from"))
         if not_reviewer:
             return not_reviewer
+        digest_error = self._check_artefact_digest(p, task)
+        if digest_error:
+            return digest_error
         now = self.now_iso()
         assert task.review is not None
         task.review.decisions.append({
@@ -1127,6 +1196,9 @@ class Coordinator:
         not_reviewer = self._require_reviewer(task, p.get("from"))
         if not_reviewer:
             return not_reviewer
+        digest_error = self._check_artefact_digest(p, task)
+        if digest_error:
+            return digest_error
         # The override is of the artefact under review; use the coordinator's
         # record, not a caller-supplied "before" that could be fabricated.
         base = task.pending_artefact

--- a/packages/coordinator-py/chap_coordinator/jsonrpc.py
+++ b/packages/coordinator-py/chap_coordinator/jsonrpc.py
@@ -26,6 +26,7 @@ class E:
     NOT_AUTHORISED = -32011
     PATCH_FAILED = -32012
     REVIEW_LAPSED = -32013
+    REVIEW_ALREADY_OPEN = -32014
 
     # whisper/1.0 profile (profiles/whisper.md S6)
     WHISPER_ALREADY_ANSWERED = -32020
@@ -58,6 +59,7 @@ class E:
     SIG_KEY_NOT_FOUND = -32071
     SIG_KEY_REVOKED = -32072
     SIG_ROTATION_KEY_MISMATCH = -32073
+    SIG_ARTEFACT_DIGEST_MISMATCH = -32074
 
     # audit-scitt/1.0 profile (profiles/audit-scitt.md S8)
     SCITT_UNREACHABLE = -32080

--- a/packages/coordinator-py/chap_coordinator/transports/mcp_schemas.py
+++ b/packages/coordinator-py/chap_coordinator/transports/mcp_schemas.py
@@ -181,6 +181,11 @@ SCHEMAS: dict[str, dict[str, Any]] = {
         "type": "object",
         "properties": {
             "workspace": _WORKSPACE_ID, "from": _PARTICIPANT_URI, "task_id": _TASK_ID,
+            "approved_artefact_digest": {
+                "type": "string",
+                "pattern": "^sha256:[0-9a-f]{64}$",
+                "description": "Optional. SHA-256 over the JCS canonicalisation of the artefact under review, as `sha256:<hex>`. Binds the decision to the exact content reviewed; refused with -32074 on mismatch.",
+            },
             "comment": {"type": "string"},
             "tags":    {"type": "array", "items": {"type": "string"}},
         },
@@ -190,6 +195,11 @@ SCHEMAS: dict[str, dict[str, Any]] = {
         "type": "object",
         "properties": {
             "workspace": _WORKSPACE_ID, "from": _PARTICIPANT_URI, "task_id": _TASK_ID,
+            "approved_artefact_digest": {
+                "type": "string",
+                "pattern": "^sha256:[0-9a-f]{64}$",
+                "description": "Optional. SHA-256 over the JCS canonicalisation of the artefact under review, as `sha256:<hex>`. Binds the decision to the exact content reviewed; refused with -32074 on mismatch.",
+            },
             "comment": {"type": "string"},
             "tags":    {"type": "array", "items": {"type": "string"}},
             "request_revision": {"type": "boolean"},
@@ -199,6 +209,11 @@ SCHEMAS: dict[str, dict[str, Any]] = {
     "chap.decide.override": {
         "type": "object",
         "properties": {
+            "approved_artefact_digest": {
+                "type": "string",
+                "pattern": "^sha256:[0-9a-f]{64}$",
+                "description": "Optional. SHA-256 over the JCS canonicalisation of the artefact under review, as `sha256:<hex>`. Binds the decision to the exact content reviewed; refused with -32074 on mismatch.",
+            },
             "workspace": _WORKSPACE_ID, "from": _PARTICIPANT_URI, "task_id": _TASK_ID,
             "diff": {
                 "type": "array",

--- a/packages/coordinator-py/tests/test_artefact_binding.py
+++ b/packages/coordinator-py/tests/test_artefact_binding.py
@@ -1,0 +1,139 @@
+"""
+review/1.0: binding a decision to the content it decided on.
+
+Two related gaps, reported against 9e7af2b by Iman Schrock (EMILIA) from the
+CHAP-to-AEB interoperability profile, and tracked as #71 and #72.
+
+A plain ``decide.approve`` bound ``task_id`` and no content, so a relying party
+could not tell what was approved. And ``review.request`` had no guard, so the
+artefact under an open review could be replaced with the decision envelope
+carrying nothing that would detect the swap.
+
+Mirrors ``packages/coordinator/tests/artefact_binding.test.ts`` case for case,
+so a divergence between the two implementations fails on one side.
+"""
+from __future__ import annotations
+
+import pytest
+
+from chap_coordinator.canonical import content_hash
+from chap_coordinator.coordinator import Coordinator, CoordinatorOptions
+
+DRAFT = {"severity": "warning", "text": "the reviewed text"}
+SWAPPED = {"severity": "critical", "text": "something else entirely"}
+
+
+def setup():
+    c = Coordinator(CoordinatorOptions(deterministic_ids=True, deterministic_clock=True))
+
+    def send(method, params):
+        return c.dispatch({"jsonrpc": "2.0", "id": f"t-{method}", "method": method, "params": params})
+
+    send("workspace.create", {"workspace": "wsp_b"})
+    for frm, role in (("human:alice", "owner"), ("human:bob", "reviewer"),
+                      ("human:carol", "reviewer"), ("agent:bot", "drafter")):
+        send("participant.join", {"workspace": "wsp_b", "from": frm, "role": role,
+                                  "type": "human" if frm.startswith("human:") else "agent"})
+    tid = send("task.create", {"workspace": "wsp_b", "from": "human:alice", "kind": "draft",
+                               "input": {}, "assignee": "agent:bot"})["result"]["task_id"]
+    send("task.update", {"workspace": "wsp_b", "from": "agent:bot", "task_id": tid, "state": "in_progress"})
+    send("task.complete", {"workspace": "wsp_b", "from": "agent:bot", "task_id": tid,
+                           "output": DRAFT, "confidence": "0.9"})
+    return c, send, tid
+
+
+def open_review(send, tid, artefact=DRAFT, to="human:bob"):
+    return send("review.request", {"workspace": "wsp_b", "from": "agent:bot",
+                                   "task_id": tid, "to": to, "artefact": artefact})
+
+
+# ---- #72: the artefact under an open review cannot be swapped ----
+
+def test_re_request_with_different_content_is_refused():
+    c, send, tid = setup()
+    open_review(send, tid)
+    r = open_review(send, tid, SWAPPED)
+    assert r["error"]["code"] == -32014
+    assert "already open" in r["error"]["message"]
+    assert c.get_workspace("wsp_b").tasks[tid].pending_artefact == DRAFT
+
+
+def test_re_request_with_same_content_widens_the_reviewer_set():
+    c, send, tid = setup()
+    open_review(send, tid)
+    r = open_review(send, tid, DRAFT, to="human:carol")
+    assert "error" not in r
+    assert r["result"]["amended"] is True
+    assert r["result"]["requested_to"] == ["human:bob", "human:carol"]
+
+    decided = send("decide.approve", {"workspace": "wsp_b", "from": "human:carol", "task_id": tid})
+    assert "error" not in decided
+    assert decided["result"]["state"] == "completed"
+
+
+def test_decision_rule_cannot_change_under_an_open_review():
+    _, send, tid = setup()
+    open_review(send, tid)
+    r = send("review.request", {"workspace": "wsp_b", "from": "agent:bot", "task_id": tid,
+                                "to": "human:carol", "artefact": DRAFT, "rule": "quorum:2"})
+    assert r["error"]["code"] == -32014
+    assert "decision rule" in r["error"]["message"]
+
+
+# ---- #71: an approval binds the content it approved ----
+
+def test_matching_digest_is_accepted():
+    _, send, tid = setup()
+    open_review(send, tid)
+    r = send("decide.approve", {"workspace": "wsp_b", "from": "human:bob", "task_id": tid,
+                                "approved_artefact_digest": content_hash(DRAFT)})
+    assert "error" not in r
+    assert r["result"]["state"] == "completed"
+
+
+def test_mismatched_digest_is_refused_and_changes_nothing():
+    c, send, tid = setup()
+    open_review(send, tid)
+    r = send("decide.approve", {"workspace": "wsp_b", "from": "human:bob", "task_id": tid,
+                                "approved_artefact_digest": content_hash(SWAPPED)})
+    assert r["error"]["code"] == -32074
+    task = c.get_workspace("wsp_b").tasks[tid]
+    assert task.state == "review_requested", "no state change on a refused decision"
+    assert task.review.decisions == [], "nothing recorded on a refused decision"
+
+
+def test_absent_digest_behaves_exactly_as_before():
+    _, send, tid = setup()
+    open_review(send, tid)
+    r = send("decide.approve", {"workspace": "wsp_b", "from": "human:bob", "task_id": tid})
+    assert "error" not in r
+    assert r["result"]["state"] == "completed"
+
+
+def test_non_string_digest_is_invalid_params():
+    _, send, tid = setup()
+    open_review(send, tid)
+    r = send("decide.approve", {"workspace": "wsp_b", "from": "human:bob", "task_id": tid,
+                                "approved_artefact_digest": 12345})
+    assert r["error"]["code"] == -32602
+
+
+def test_override_binds_the_base_artefact_the_same_way():
+    _, send, tid = setup()
+    open_review(send, tid)
+    bad = send("decide.override", {"workspace": "wsp_b", "from": "human:bob", "task_id": tid,
+                                   "diff": [{"op": "replace", "path": "/severity", "value": "info"}],
+                                   "rationale": "false positive",
+                                   "approved_artefact_digest": content_hash(SWAPPED)})
+    assert bad["error"]["code"] == -32074
+
+    ok = send("decide.override", {"workspace": "wsp_b", "from": "human:bob", "task_id": tid,
+                                  "diff": [{"op": "replace", "path": "/severity", "value": "info"}],
+                                  "rationale": "false positive",
+                                  "approved_artefact_digest": content_hash(DRAFT)})
+    assert "error" not in ok
+
+
+def test_digest_is_the_same_construction_the_chain_uses():
+    import re
+    assert re.fullmatch(r"sha256:[0-9a-f]{64}", content_hash(DRAFT))

--- a/packages/coordinator/src/coordinator.ts
+++ b/packages/coordinator/src/coordinator.ts
@@ -20,7 +20,7 @@
  *   - identity-oidc/1.0 + identity-vc/1.0 (binding hooks at join)
  */
 
-import { canonicalize, sha256Hex, ZERO_HASH } from "./canonical.js";
+import { canonicalize, contentHash, sha256Hex, ZERO_HASH } from "./canonical.js";
 import { publicKeyFromJwk, verifyEnvelope } from "./crypto.js";
 import { IdFactory } from "./ids.js";
 import { E, isValidEnvelope, rpcError } from "./jsonrpc.js";
@@ -1008,18 +1008,87 @@ export class Coordinator {
     const reviewers: string[] = Array.isArray(to) ? (to as string[]) : typeof to === "string" ? [to] : [];
     if (!reviewers.length) return { error: rpcError(E.PARAMS, "review.request needs 'to'") };
     const now = this.now();
+    const rule = (p.rule as string) || "any_one_approves";
+
+    // A review already open on this task. Replacing the artefact underneath
+    // it would let a reviewer decide on content they never saw, and would
+    // discard decisions already cast while their envelopes remain in the
+    // audit log, so a quorum could appear to have been assembled across two
+    // different artefacts. Re-requesting the *same* artefact is a different
+    // thing: it widens the reviewer set on an open review, which is legitimate
+    // and preserves what has been decided so far.
+    if (task.state === "review_requested" && task.review) {
+      if (contentHash(task.pending_artefact) !== contentHash(p.artefact)) {
+        return { error: rpcError(
+          E.REVIEW_ALREADY_OPEN,
+          "A review is already open on this task with different content. " +
+          "Decide, abstain, escalate or cancel it before requesting review of a new artefact.",
+        ) };
+      }
+      if (rule !== task.review.rule) {
+        return { error: rpcError(
+          E.REVIEW_ALREADY_OPEN,
+          `Cannot change the decision rule of an open review (currently ${task.review.rule})`,
+        ) };
+      }
+      // Union, preserving order and the decisions already recorded.
+      for (const r of reviewers) {
+        if (!task.review.requested_to.includes(r)) task.review.requested_to.push(r);
+      }
+      if (p.deadline !== undefined) task.review.deadline = p.deadline as string;
+      task.updated_at = now;
+      return { result: {
+        state: "review_requested",
+        review_id: task.id,
+        amended: true,
+        requested_to: [...task.review.requested_to],
+      } };
+    }
+
     task.state = "review_requested";
     task.updated_at = now;
     task.review = {
       requested_at: now,
       requested_to: reviewers,
-      rule: (p.rule as string) || "any_one_approves",
+      rule,
       deadline: p.deadline as string | undefined,
       decisions: [],
     };
     task.history.push({ ts: now, from: p.from as ParticipantUri, state: "review_requested" });
     task.pending_artefact = p.artefact;
     return { result: { state: "review_requested", review_id: task.id } };
+  }
+
+  /**
+   * Verify an optional `approved_artefact_digest` against the artefact under
+   * review (review/1.0 S3.2).
+   *
+   * The digest sits in params, so it is inside whatever the envelope signature
+   * covers: the decision then attests the content the reviewer saw rather than
+   * a task reference, and a relying party can check it without trusting the
+   * Coordinator that produced it. Absent, behaviour is exactly as before.
+   *
+   * On mismatch nothing is recorded and no state changes, so a client that
+   * computes the wrong digest refuses only its own decision.
+   */
+  private checkArtefactDigest(p: Record<string, unknown>, task: Task): ReturnType<Handler> | null {
+    const declared = p.approved_artefact_digest;
+    if (declared === undefined || declared === null) return null;
+    if (typeof declared !== "string") {
+      return { error: rpcError(E.PARAMS, "approved_artefact_digest must be a string") };
+    }
+    if (task.pending_artefact === undefined) {
+      return { error: rpcError(E.PARAMS, "No artefact under review to bind a digest to") };
+    }
+    const actual = contentHash(task.pending_artefact);
+    if (declared !== actual) {
+      return { error: rpcError(
+        E.SIG_ARTEFACT_DIGEST_MISMATCH,
+        "approved_artefact_digest does not match the artefact under review",
+        { declared, actual },
+      ) };
+    }
+    return null;
   }
 
   private opDecide(p: Record<string, unknown>, kind: "approve" | "reject"): ReturnType<Handler> {
@@ -1038,6 +1107,8 @@ export class Coordinator {
     }
     const notReviewer = this.requireReviewer(task, p.from);
     if (notReviewer) return notReviewer;
+    const digestError = this.checkArtefactDigest(p, task);
+    if (digestError) return digestError;
     const now = this.now();
     task.review!.decisions.push({
       reviewer: p.from as ParticipantUri,
@@ -1073,6 +1144,8 @@ export class Coordinator {
     }
     const notReviewer = this.requireReviewer(task, p.from);
     if (notReviewer) return notReviewer;
+    const digestError = this.checkArtefactDigest(p, task);
+    if (digestError) return digestError;
     // The override is of the artefact under review; use the coordinator's
     // record, not a caller-supplied "before" that could be fabricated.
     const base = task.pending_artefact;

--- a/packages/coordinator/src/jsonrpc.ts
+++ b/packages/coordinator/src/jsonrpc.ts
@@ -20,6 +20,7 @@ export const E = {
   NOT_AUTHORISED: -32011,
   PATCH_FAILED:   -32012,
   REVIEW_LAPSED:  -32013,
+  REVIEW_ALREADY_OPEN: -32014,
 
   // whisper/1.0 profile (profiles/whisper.md S6)
   WHISPER_ALREADY_ANSWERED:    -32020,
@@ -52,6 +53,7 @@ export const E = {
   SIG_KEY_NOT_FOUND:         -32071,
   SIG_KEY_REVOKED:           -32072,
   SIG_ROTATION_KEY_MISMATCH: -32073,
+  SIG_ARTEFACT_DIGEST_MISMATCH: -32074,
 
   // audit-scitt/1.0 profile (profiles/audit-scitt.md S8)
   SCITT_UNREACHABLE:        -32080,

--- a/packages/coordinator/tests/artefact_binding.test.ts
+++ b/packages/coordinator/tests/artefact_binding.test.ts
@@ -1,0 +1,139 @@
+/**
+ * review/1.0: binding a decision to the content it decided on.
+ *
+ * Two related gaps, reported against 9e7af2b by Iman Schrock (EMILIA) from the
+ * CHAP-to-AEB interoperability profile, and tracked as #71 and #72.
+ *
+ * A plain `decide.approve` bound `task_id` and no content, so a relying party
+ * could not tell what was approved. And `review.request` had no guard, so the
+ * artefact under an open review could be replaced with the decision envelope
+ * carrying nothing that would detect the swap.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { Coordinator } from "../src/index.js";
+import { contentHash } from "../src/canonical.js";
+
+const DRAFT = { severity: "warning", text: "the reviewed text" };
+const SWAPPED = { severity: "critical", text: "something else entirely" };
+
+function setup() {
+  const c = new Coordinator({ deterministicIds: true, deterministicClock: true });
+  const send = (m: string, p: Record<string, unknown>) =>
+    c.dispatch({ jsonrpc: "2.0", id: `t-${m}`, method: m, params: p }) as
+      { result?: Record<string, unknown>; error?: { code: number; message: string; data?: unknown } };
+  send("workspace.create", { workspace: "wsp_b" });
+  for (const [from, role] of [["human:alice", "owner"], ["human:bob", "reviewer"],
+                              ["human:carol", "reviewer"], ["agent:bot", "drafter"]]) {
+    send("participant.join", { workspace: "wsp_b", from, role,
+      type: from.startsWith("human:") ? "human" : "agent" });
+  }
+  const r = send("task.create", { workspace: "wsp_b", from: "human:alice",
+    kind: "draft", input: {}, assignee: "agent:bot" });
+  const tid = (r.result as { task_id: string }).task_id;
+  send("task.update", { workspace: "wsp_b", from: "agent:bot", task_id: tid, state: "in_progress" });
+  send("task.complete", { workspace: "wsp_b", from: "agent:bot", task_id: tid,
+    output: DRAFT, confidence: "0.9" });
+  return { c, send, tid };
+}
+
+function openReview(send: ReturnType<typeof setup>["send"], tid: string, artefact: unknown = DRAFT, to = "human:bob") {
+  return send("review.request", { workspace: "wsp_b", from: "agent:bot", task_id: tid, to, artefact });
+}
+
+// ---- #72: the artefact under an open review cannot be swapped ----
+
+test("re-requesting review with different content is refused", () => {
+  const { send, tid, c } = setup();
+  openReview(send, tid);
+  const r = openReview(send, tid, SWAPPED);
+  assert.equal(r.error?.code, -32014);
+  assert.match(r.error!.message, /already open/);
+  const task = (c as unknown as { workspaces: Map<string, { tasks: Map<string, { pending_artefact: unknown }> }> })
+    .workspaces.get("wsp_b")!.tasks.get(tid)!;
+  assert.deepEqual(task.pending_artefact, DRAFT, "the artefact under review is untouched");
+});
+
+test("re-requesting with the same content widens the reviewer set and keeps decisions", () => {
+  const { send, tid, c } = setup();
+  openReview(send, tid);
+  const r = openReview(send, tid, DRAFT, "human:carol");
+  assert.equal(r.error, undefined);
+  assert.equal(r.result!.amended, true);
+  assert.deepEqual(r.result!.requested_to, ["human:bob", "human:carol"]);
+
+  // Carol, added by the amendment, is now eligible.
+  const decided = send("decide.approve", { workspace: "wsp_b", from: "human:carol", task_id: tid });
+  assert.equal(decided.error, undefined);
+  assert.equal(decided.result!.state, "completed");
+  void c;
+});
+
+test("the decision rule cannot be changed under an open review", () => {
+  const { send, tid } = setup();
+  openReview(send, tid);
+  const r = send("review.request", { workspace: "wsp_b", from: "agent:bot", task_id: tid,
+    to: "human:carol", artefact: DRAFT, rule: "quorum:2" });
+  assert.equal(r.error?.code, -32014);
+  assert.match(r.error!.message, /decision rule/);
+});
+
+// ---- #71: an approval binds the content it approved ----
+
+test("a matching approved_artefact_digest is accepted", () => {
+  const { send, tid } = setup();
+  openReview(send, tid);
+  const r = send("decide.approve", { workspace: "wsp_b", from: "human:bob", task_id: tid,
+    approved_artefact_digest: contentHash(DRAFT) });
+  assert.equal(r.error, undefined);
+  assert.equal(r.result!.state, "completed");
+});
+
+test("a mismatched digest is refused and changes nothing", () => {
+  const { send, tid, c } = setup();
+  openReview(send, tid);
+  const r = send("decide.approve", { workspace: "wsp_b", from: "human:bob", task_id: tid,
+    approved_artefact_digest: contentHash(SWAPPED) });
+  assert.equal(r.error?.code, -32074);
+  const ws = (c as unknown as { workspaces: Map<string, {
+    tasks: Map<string, { state: string; review: { decisions: unknown[] } }> }> }).workspaces.get("wsp_b")!;
+  const task = ws.tasks.get(tid)!;
+  assert.equal(task.state, "review_requested", "no state change on a refused decision");
+  assert.equal(task.review.decisions.length, 0, "nothing recorded on a refused decision");
+});
+
+test("an absent digest behaves exactly as before", () => {
+  const { send, tid } = setup();
+  openReview(send, tid);
+  const r = send("decide.approve", { workspace: "wsp_b", from: "human:bob", task_id: tid });
+  assert.equal(r.error, undefined);
+  assert.equal(r.result!.state, "completed");
+});
+
+test("a non-string digest is invalid params, not a mismatch", () => {
+  const { send, tid } = setup();
+  openReview(send, tid);
+  const r = send("decide.approve", { workspace: "wsp_b", from: "human:bob", task_id: tid,
+    approved_artefact_digest: 12345 });
+  assert.equal(r.error?.code, -32602);
+});
+
+test("decide.override binds the base artefact the same way", () => {
+  const { send, tid } = setup();
+  openReview(send, tid);
+  const bad = send("decide.override", { workspace: "wsp_b", from: "human:bob", task_id: tid,
+    diff: [{ op: "replace", path: "/severity", value: "info" }], rationale: "false positive",
+    approved_artefact_digest: contentHash(SWAPPED) });
+  assert.equal(bad.error?.code, -32074);
+
+  const ok = send("decide.override", { workspace: "wsp_b", from: "human:bob", task_id: tid,
+    diff: [{ op: "replace", path: "/severity", value: "info" }], rationale: "false positive",
+    approved_artefact_digest: contentHash(DRAFT) });
+  assert.equal(ok.error, undefined);
+});
+
+test("the digest is the same construction the evidence chain uses", () => {
+  // Not a new primitive: SHA-256 over JCS, prefixed, exactly as contentHash.
+  assert.match(contentHash(DRAFT), /^sha256:[0-9a-f]{64}$/);
+});

--- a/profiles/review.md
+++ b/profiles/review.md
@@ -71,10 +71,68 @@ task whose `review.required` was true.
 Supported `rule` values: `any_one_approves`, `all_approve`.
 The `deliberation` profile adds richer rules (`quorum:N`, weighted).
 
+**Re-request on an open review.** A review already open on the task
+constrains what a second `review.request` may do.
+
+- If the `artefact` is byte-identical under JCS to the one already
+  under review, the request is an **amendment**: the reviewers in `to`
+  are added to the existing set, decisions already cast are preserved,
+  and the result carries `"amended": true` with the resulting
+  `requested_to`. This is how a reviewer is added to a review in
+  flight.
+- If the `artefact` differs, the Coordinator MUST refuse with `-32014`
+  and change nothing. Replacing the artefact underneath an open review
+  would let a reviewer decide on content they never saw, and would
+  discard decisions already cast while their envelopes remain in the
+  audit log, so a quorum could appear to have been assembled across two
+  different artefacts. To review new content, first close the open
+  review with a decision, an abstention, an escalation, or
+  `control.cancel`.
+- A request that would change the `rule` of an open review MUST also be
+  refused with `-32014`. The rule under which reviewers agreed to
+  decide is fixed for the life of that review.
+
 ### 3.2 `decide.approve` · `decide.reject`
 
 Straightforward. The reviewer's identity, comment, and tags are
 preserved as a `decision` artefact.
+
+**Binding the decision to the content (`approved_artefact_digest`).**
+A decision names `task_id`, which identifies *which* review it settles
+but not *what* was decided. A relying party consuming the decision as
+evidence therefore cannot tell, from the envelope alone, which content
+the human actually approved.
+
+`decide.approve`, `decide.reject` and `decide.override` accept an
+optional `approved_artefact_digest`: SHA-256 over the RFC 8785 (JCS)
+canonicalisation of the artefact under review, in the same
+`sha256:<hex>` form the evidence chain already uses. The reviewer's
+client computes it from the artefact the human was shown at
+`review.request`.
+
+Because the digest sits in `params`, it falls inside whatever the
+envelope signature covers under `security-signed/1.0`. The decision
+then attests content rather than a task reference, and a relying party
+can verify it against the artefact without trusting the Coordinator
+that produced the decision.
+
+When present, the Coordinator MUST compute the digest of the artefact
+under review and compare. On mismatch it MUST refuse with `-32074`,
+record no decision, and change no state. When absent, behaviour is
+exactly as it was: the field is optional and additive.
+
+```json
+{
+  "method": "decide.approve",
+  "params": {
+    "workspace":  "wsp_demo",
+    "from":       "human:alice@example.org",
+    "task_id":    "tsk_…",
+    "approved_artefact_digest": "sha256:9f2c…",
+    "comment":    "Reads well, ship it."
+  }
+}
+```
 
 **Eligibility.** The actor (`from`) of any review decision MUST be a
 joined workspace member (Core §6.3.1) **and** MUST be one of the
@@ -285,6 +343,7 @@ piece of the protocol is plumbing.
 | `-32011`  | Actor is not authorised: not a workspace member, or a member who was not an addressed reviewer for this task. |
 | `-32012`  | JSON Patch application failed (with path in `data`).   |
 | `-32013`  | Review deadline has lapsed.                            |
+| `-32014`  | A review is already open on this task with different content, or the request would change the decision rule of an open review. |
 
 ---
 

--- a/profiles/security-signed.md
+++ b/profiles/security-signed.md
@@ -166,6 +166,7 @@ the revocation. Messages dated after are rejected with `-32070`.
 | `-32071`  | No known key matching `from` + `kid` + `ts`.     |
 | `-32072`  | Key has been revoked.                            |
 | `-32073`  | Rotation message not signed with old key.        |
+| `-32074`  | `approved_artefact_digest` does not match the artefact under review. |
 
 ---
 

--- a/reference/core-plus-review/server.ts
+++ b/reference/core-plus-review/server.ts
@@ -14,6 +14,7 @@
  */
 
 import { createServer, IncomingMessage, ServerResponse } from "node:http";
+import { createHash } from "node:crypto";
 
 // ============================================================
 //   Types
@@ -146,7 +147,45 @@ const E = {
   NOT_AUTHORISED:   -32011,
   PATCH_FAILED:     -32012,
   REVIEW_LAPSED:    -32013,
+  REVIEW_ALREADY_OPEN: -32014,
+  // security-signed codes used by review decisions (CEP-001)
+  SIG_ARTEFACT_DIGEST_MISMATCH: -32074,
 } as const;
+
+/**
+ * JCS canonicalisation and the `sha256:<hex>` content digest, implemented
+ * locally: this server is a from-scratch reference and deliberately shares no
+ * code with the packages, which is what makes it useful as an interop check.
+ */
+function jcs(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return "[" + value.map(jcs).join(",") + "]";
+  const keys = Object.keys(value as Record<string, unknown>).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  return "{" + keys.map(k => JSON.stringify(k) + ":" + jcs((value as Record<string, unknown>)[k])).join(",") + "}";
+}
+
+function contentDigest(value: unknown): string {
+  return "sha256:" + createHash("sha256").update(jcs(value), "utf-8").digest("hex");
+}
+
+/** CEP-001: an optional digest binds a decision to the artefact under review. */
+function checkArtefactDigest(p: Params, task: any): ReturnType<typeof err> | null {
+  const declared = p.approved_artefact_digest;
+  if (declared === undefined || declared === null) return null;
+  if (typeof declared !== "string") {
+    return err(E.PARAMS, "approved_artefact_digest must be a string");
+  }
+  if (task.pending_artefact === undefined) {
+    return err(E.PARAMS, "No artefact under review to bind a digest to");
+  }
+  const actual = contentDigest(task.pending_artefact);
+  if (declared !== actual) {
+    return err(E.SIG_ARTEFACT_DIGEST_MISMATCH,
+      "approved_artefact_digest does not match the artefact under review",
+      { declared, actual });
+  }
+  return null;
+}
 
 function err(code: number, message: string, data?: unknown) {
   return { code, message, ...(data !== undefined ? { data } : {}) };
@@ -430,12 +469,34 @@ const handlers: Record<string, Handler> = {
     if (!task) return { error: err(E.PARAMS, `Unknown task`) };
 
     const reviewers = Array.isArray(p.to) ? (p.to as string[]) : [p.to as string];
+    const rule = (p.rule as string) ?? "any_one_approves";
+
+    // CEP-001: an open review may be widened, not swapped underneath.
+    if (task.state === "review_requested" && task.review) {
+      if (contentDigest((task as any).pending_artefact) !== contentDigest(p.artefact)) {
+        return { error: err(E.REVIEW_ALREADY_OPEN,
+          "A review is already open on this task with different content. " +
+          "Decide, abstain, escalate or cancel it before requesting review of a new artefact.") };
+      }
+      if (rule !== task.review.rule) {
+        return { error: err(E.REVIEW_ALREADY_OPEN,
+          `Cannot change the decision rule of an open review (currently ${task.review.rule})`) };
+      }
+      for (const r of reviewers) {
+        if (!task.review.requested_to.includes(r)) task.review.requested_to.push(r);
+      }
+      if (p.deadline !== undefined) task.review.deadline = p.deadline as string;
+      task.updated_at = new Date().toISOString();
+      return { result: { state: "review_requested", review_id: task.id, amended: true,
+                         requested_to: [...task.review.requested_to] } };
+    }
+
     task.state = "review_requested";
     task.updated_at = new Date().toISOString();
     task.review = {
       requested_at: task.updated_at,
       requested_to: reviewers,
-      rule:         (p.rule as string) ?? "any_one_approves",
+      rule,
       deadline:     p.deadline as string,
       decisions:    [],
     };
@@ -467,6 +528,8 @@ const handlers: Record<string, Handler> = {
     }
     const notReviewer = requireReviewer(task, p.from);
     if (notReviewer) return { error: notReviewer };
+    const digestError = checkArtefactDigest(p, task);
+    if (digestError) return { error: digestError };
 
     const baseArtefact = p.based_on_artefact ?? (task as any).pending_artefact;
     if (baseArtefact === undefined) {
@@ -594,6 +657,8 @@ function decide(p: Params, kind: "approve" | "reject"): { result?: unknown; erro
   }
   const notReviewer = requireReviewer(task, p.from);
   if (notReviewer) return { error: notReviewer };
+  const digestError = checkArtefactDigest(p, task);
+  if (digestError) return { error: digestError };
 
   const now = new Date().toISOString();
   task.review!.decisions.push({


### PR DESCRIPTION
Closes #71 and #72. Reported by Iman Schrock (EMILIA) from a source-pinned CHAP-to-AEB interoperability profile that consumes CHAP decisions as admission evidence, emiliaprotocol/emilia-protocol#582.

A signed decide.override already carried enough to map the patched artefact to an exact action. A plain decide.approve bound task_id and no content, so a relying party could not tell what had been approved and their adapter correctly returned INDETERMINATE rather than guess.

Verifying that surfaced a second consequence. review.request had no guard against re-request, so the artefact under an open review could be replaced and the decision envelope carried nothing that would detect the swap. Under a quorum rule this was worse than it first appears: the replacement built a fresh review with an empty decision list, so decisions already cast were discarded while their envelopes remained in the audit log, leaving what reads as a quorum assembled across two different artefacts.

The digest

decide.approve, decide.reject and decide.override take an optional approved_artefact_digest: SHA-256 over the RFC 8785 canonicalisation of the artefact under review, in the sha256:<hex> form the evidence chain already uses. It is the existing content-hash construction, not a new primitive. The Coordinator verifies it and refuses a mismatch with -32074, recording no decision and changing no state. Absent, behaviour is unchanged.

The field sits in params, so it falls inside whatever the envelope signature covers. The decision then attests content rather than a task reference, and a relying party can verify it without trusting the Coordinator that produced it.

The state machine

review.request on a task already in review_requested now distinguishes two cases. An identical artefact is an amendment: reviewers in `to` are added to the existing set, decisions already cast are preserved, and the result carries amended: true. This is how a reviewer is added to a review in flight, which matters because a review addresses a set under a rule. A different artefact is refused with -32014, as is a request that would change the decision rule mid-review.

Refusing costs nothing, because the revise-and-resubmit path already exists through decide.reject returning the task to in_progress.

Scope

Both coordinators, and the from-scratch reference server in reference/core-plus-review, which shares no code with the packages and so needed the same change independently. Conformance vectors rv-09, rv-10 and rv-11 pass against both reference servers. rv-10 decides again after the refusal, so a Coordinator that recorded the refused decision or closed the review fails on the second call rather than the first.

GOVERNANCE pointed CEPs at heps/, a directory that did not exist and looks like a typo; corrected to ceps/, which this proposal creates.