### PR TITLE
Restore lost changelog history and reconcile the documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,8 +148,17 @@ jobs:
           python-version: '3.12'
 
       - name: Em-dash check
+        # Was markdown only, which let em-dashes accumulate in shipped UI copy,
+        # schema descriptions and package descriptions. This workflow is
+        # excluded because it contains the character it searches for.
         run: |
-          OFFENDERS=$(find . -name "*.md" -not -path "./node_modules/*" -not -path "*/dist/*" -exec grep -l "—" {} \; 2>/dev/null)
+          OFFENDERS=$(find . \
+            \( -name "*.md" -o -name "*.ts" -o -name "*.js" -o -name "*.py" \
+               -o -name "*.json" -o -name "*.html" -o -name "*.css" -o -name "*.tape" \) \
+            -not -path "./node_modules/*" -not -path "*/node_modules/*" \
+            -not -path "*/dist/*" -not -path "./.github/workflows/ci.yml" \
+            -not -name "package-lock.json" \
+            -exec grep -l "—" {} \; 2>/dev/null)
           if [ -n "$OFFENDERS" ]; then
             echo "::error::Em-dashes found in: $OFFENDERS"
             for f in $OFFENDERS; do
@@ -170,6 +179,22 @@ jobs:
             exit 1
           fi
           echo "No build artefacts tracked."
+
+      - name: No bare require() in ES modules
+        # Three separate faults this release traced to the same mistake: a
+        # bare require() in an ES module, which is undefined at runtime.
+        # ids.ts took down Node 18, and two in the storage layer hid the
+        # SQLite suites for months. createRequire is the ESM-correct form.
+        run: |
+          OFFENDERS=$(grep -rn --include="*.ts" -E "(^|[^.[:alnum:]_])require\(" \
+            packages/*/src packages/*/tests reference/*/*.ts conformance/harness 2>/dev/null \
+            | grep -v "createRequire" || true)
+          if [ -n "$OFFENDERS" ]; then
+            echo "::error::Bare require() found in ES module sources. Use createRequire(import.meta.url):"
+            echo "$OFFENDERS"
+            exit 1
+          fi
+          echo "No bare require() in ES module sources."
 
       - name: Markdown link integrity
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,48 @@ incremented under the same rules.
 
 ## Unreleased
 
+### Documentation consistency
+
+- **The 0.2.7 changelog section is restored.** 218 lines covering the four
+  framework bridges, the scenarios directory and the cross-implementation
+  fixes were lost between 9e7af2b and the 0.2.9 work, and recovered verbatim.
+  A 0.2.8 entry is added; that release published the 0.2.7 line and carried no
+  change of its own.
+
+- **The error registry matches the implementations.** SPECIFICATION.md §13.2
+  assigned overlapping bands, which produced §13.3 giving `-32600`, `-32601`
+  and `-32602` two meanings each and naming errors neither coordinator
+  returns. §13.2 now allocates one decade per profile with no overlap, and
+  §13.3 carries only the five JSON-RPC codes, treating each profile's own
+  table as authoritative rather than mirroring 49 codes that would drift again.
+
+- **`identity-vc/1.0` error codes corrected.** The profile assigned `-32411`
+  to issuer trust and `-32413` to claim disclosure, while both implementations
+  use them for holder binding and unknown schema. The table now matches what
+  is returned, and the two conditions that exist only on paper are recorded as
+  unimplemented rather than deleted.
+
+- **One name for the proposal process.** CONTRIBUTING called it "CHAP
+  Improvement Proposals" in one place and "RFC-style proposal" in three
+  others, while GOVERNANCE defines CEPs. All now say CEP, and CONTRIBUTING
+  points at `ceps/` and the governing section.
+
+- **`MAINTAINERS.md` exists.** SECURITY, GOVERNANCE and CODE_OF_CONDUCT all
+  referred readers to a file that was not there. It records the present
+  position plainly: two maintainers, with protocol decisions resting with
+  Arsalan Shahid, and the Steering Committee and Working Groups in
+  GOVERNANCE §2 described as the structure intended for standards-track
+  promotion rather than today.
+
+- **Em-dashes removed from shipped non-markdown files**, and the CI check
+  widened past `*.md` to the source, schema and UI files where they had
+  accumulated.
+
+- **A CI guard for bare `require()` in ES modules.** Three faults this release
+  had the same cause, and the guard immediately found a fourth: the
+  corrupt-row recovery suite had been skipping silently for the same reason as
+  the storage suites.
+
 ### Storage contract and verification limits (#69)
 
 - **The store contract no longer claims optimistic concurrency.**
@@ -204,6 +246,237 @@ or rejects each request independently.
 
 - npm packages under the `@brightbeamai/` scope; the full nine-package set now
   published on npm and PyPI. Stopped tracking Python bytecode caches. (#60)
+
+---
+
+## 0.2.8: publish of the 0.2.7 line
+
+A packaging release. `chap-coordinator` on PyPI and
+`@brightbeamai/chap-coordinator` on npm were published from this tag; the
+other seven packages remained unpublished until 0.2.9.
+
+The protocol and implementation changes it carried are recorded under 0.2.7
+below, whose entry was expanded rather than duplicated at the time. No
+change is unique to 0.2.8.
+
+---
+
+## 0.2.7: framework adopters, the scenarios directory, and cross-implementation fixes
+
+Adds four framework bridges and a runnable `scenarios/` directory, and
+hardens the two reference implementations for their first registry
+publish. Most of this release is additive, but it also includes a
+normative canonicalisation change (numbers restricted to safe integers, to
+guarantee byte-identical hashing across implementations) and a JSON Patch
+prototype-pollution fix; see Changed and Security below. Both changes can
+affect envelopes that carried non-integer numbers, so read those sections
+before upgrading.
+
+### Added
+
+- **Four framework adopters**, joining `chap-langgraph` (shipped in 0.2.5).
+  Each bridges a real agent framework's human-in-the-loop mechanism to
+  CHAP's `review`/`decide` methods, so an approval, edit, or denial in the
+  framework becomes a `decide.approve` / `decide.override` /
+  `decide.reject` on the audit chain:
+  - **`chap-pydantic-ai`** (`ChapApprovalBridge`): bridges
+    [Pydantic AI](https://ai.pydantic.dev)'s deferred-tool approval flow.
+    An edit before approval records an override with the diff; per-call
+    rationale and tags come from the tool-result metadata.
+  - **`chap-ag2`** (`ChapTurnBridge`): bridges
+    [AG2](https://github.com/ag2ai/ag2) (AutoGen) agent turns.
+  - **`chap-llama-index`** (`ChapHitlBridge`): bridges
+    [LlamaIndex Workflows](https://developers.llamaindex.ai/python/framework/understanding/workflows/)
+    human-in-the-loop events.
+  - **`chap-google-adk`**: bridges
+    [Google ADK](https://google.github.io/adk-docs/) human-in-the-loop
+    tool confirmations.
+
+  All four join both the agent and the reviewer, address the review to the
+  approver, and decide from the approver, so they satisfy the actor
+  membership and reviewer-set eligibility rules added in 0.2.6. Each ships
+  with tests that run against the reference coordinator with authorisation
+  enforcement active, plus a runnable example. The frameworks themselves
+  are optional dependencies; the bridges and their tests do not require
+  them installed.
+
+- **`scenarios/` directory**: runnable, community-contributed domain
+  narratives on CHAP core, one self-contained folder per scenario, kept
+  distinct from `examples/` (capability walkthroughs) and the adapters'
+  own `examples/` (framework demos). Includes a catalog README (all twelve
+  `IN_PRACTICE.md` scenarios with status, labels, layout, and a
+  definition-of-done) and the first three worked examples:
+  - **`01-solo-dev-overrides/`** in two tiers: a zero-dependency
+    `scenario.py` (core/1.0 + review/1.0 + audit-scitt/1.0) that records a
+    mix of decisions, verifies the hash-linked chain, reconstructs one
+    override, and prints an override learning report; and a `system/`
+    implementation driving the same story through a real Pydantic AI agent
+    whose review action is approval-gated, offline and reproducible, with a
+    documented one-line path to a live model.
+  - **`02-marketing-copy/`**: one drafter, one editor; overrides tagged and
+    aggregated into an opener-rewrite report.
+  - **`03-founder-inbox/`**: a support inbox reconstructed from the chain,
+    with a repeated wrong-policy pattern surfaced across tickets.
+
+### Changed
+
+- **Canonicalisation now restricts numbers to safe integers.** A number in
+  a CHAP envelope or artefact must be an integer with absolute value at
+  most 2^53 - 1; non-integers and larger magnitudes are rejected and must
+  be represented as strings (for example `"8.2"`). This makes the Python
+  and TypeScript canonicalisers produce byte-identical output by
+  construction, so a chain or signature written by one implementation
+  verifies against the other. Previously each implementation formatted some
+  numbers differently (for example `1e-7`), which could break
+  cross-implementation verification. **Potentially breaking:** an envelope
+  that carried a non-integer number as a JSON number is now rejected;
+  carry it as a string. Integer-only payloads are unaffected. See the
+  number-format note in `SPECIFICATION.md` and the shared vectors in
+  `conformance/canonical-number-vectors.json`.
+- **`confidence` accepts a string as well as a number.** Because a
+  confidence score is typically a decimal and is recorded in the audit
+  envelope, it follows the canonical-number rule: pass a decimal as a
+  string (`"0.9"`). The routing engine coerces it to a number for its
+  thresholds, so routing behaviour is unchanged.
+- **JSON Patch (`decide.override`) is now full RFC 6902 in both
+  implementations.** The TypeScript coordinator previously supported only
+  `add`/`replace`/`remove` and threw on `move`/`copy`/`test`, auto-created
+  missing intermediate objects on `add`, and silently ignored array append
+  (`/-`) and out-of-range operations. It now matches the Python reference
+  exactly (all six operations, correct array insert/append, out-of-range
+  operations raise). Pinned by `conformance/json-patch-vectors.json`.
+- `IMPLEMENTATIONS.md` updated: the four new bridges added to the registry
+  with their test counts, and the `chap-langgraph` row bumped to 0.2.7.
+- **Canonicalisation is enforced at the dispatch boundary.** An inbound
+  envelope that fails to canonicalise (for example, one carrying a
+  non-integer JSON number) is rejected with `-32602` at dispatch rather
+  than being accepted and failing later when its audit entry is hashed.
+- **`participant.join` is idempotent for re-joins.** When an existing member
+  re-joins, newly attested keys and OIDC/VC identity fields are merged into
+  the existing member record rather than replacing it, so a participant can
+  rotate or add a signing key without dropping prior keys.
+- **Non-object JSON-RPC `params` are rejected as `-32602` (Invalid
+  params)** in both implementations, rather than being passed to a handler
+  (which previously could raise an opaque internal error). CHAP methods use
+  by-name params, so a non-object `params` is always invalid.
+- **Clarified reviewer scoping for `group:` targets.** A review addressed
+  to a `group:` URI is satisfied by any workspace member: the coordinator
+  does not model group membership, so it cannot restrict a decision to a
+  named group on its own. Deployments that need true group restriction must
+  enforce it externally. This is now stated explicitly in the code and
+  `SPECIFICATION.md`; a future profile may add a first-class group model.
+  (Behaviour is unchanged; this is a documentation correction.)
+
+### Security
+
+- **`task.complete` now enforces its legal source states (both
+  implementations).** Completion previously rejected only `completed` and
+  `declined` tasks, so a `cancelled` or `superseded` task could be revived
+  by completing it, and a `paused` task could be completed to bypass the
+  pause. Completion is now allowed only from `created` or `in_progress`
+  (an allowlist, so any other state is rejected). The `task.status`
+  transition table already enforced this for status changes; this closes
+  the equivalent hole on the dedicated completion path.
+- **`whisper/1.0` answers now require the answerer to be an addressed askee
+  (both implementations).** `whisper.answer` previously accepted an answer
+  from any caller, so a party the question was not directed at could answer
+  a directed whisper and have it recorded as authoritative. Only a
+  participant in the whisper's `askee` set may now answer; a broadcast
+  scope (`workspace:`/`group:`) is satisfied by any member, consistent with
+  reviewer scoping. The existing already-answered, lapsed, and
+  option-in-set checks are unchanged.
+- **`handoff/1.0` methods now require workspace membership (both
+  implementations).** The ownership check (proposer must be the current
+  assignee of each task, `HANDOFF_TASKS_NOT_ASSIGNED_TO_PROPOSER`) and the
+  recipient-membership check were already enforced; the added floor closes
+  a gap where a non-member could call `handoff.decline` to write decline
+  metadata onto a handoff.
+- **`deliberation/1.0` open/close/comment now require workspace membership
+  (both implementations).** These methods previously performed no
+  membership check, so a non-member could open a deliberation (choosing its
+  rule, participants, weights, and veto set) or call `deliberate.close` to
+  finalize the tally early. Membership is now enforced at dispatch for all
+  `deliberate.*` methods. The existing per-voter eligibility
+  (`DELIB_VOTER_NOT_IN_LIST`) and double-vote (`DELIB_ALREADY_VOTED`) checks
+  are unchanged and continue to apply.
+- **`control/1.0` operations now require workspace membership (both
+  implementations).** None of the control methods
+  (`pause`/`resume`/`cancel`/`snapshot`/`rollback`/`supersede`/`set_mode_ceiling`)
+  previously performed any authorization check, so a non-member could
+  defeat the governance "emergency brake" -- for example resume a workspace
+  a governor had paused, raise the mode ceiling to escalate autonomy, or
+  cancel in-flight tasks. All `control.*` methods now enforce the
+  membership floor at dispatch. (Deployments needing a stricter role gate
+  than membership layer it on top via an identity-* profile or application
+  check; `control.rollback` remains append-only and does not truncate the
+  audit chain.)
+- **Signature verification now fails closed (`security-signed/1.0`, both
+  implementations).** When `require_signatures` is enabled and a signature
+  is present but cannot be verified (missing `from`/`workspace`, or an
+  unknown workspace), the request is now rejected rather than silently
+  skipped. Previously these cases returned "no error", so a request with an
+  unverifiable signature could proceed; notably `workspace.create` accepted
+  a garbage signature because the workspace did not yet exist at
+  verification time. `workspace.create` (like `participant.join`) is now an
+  explicit bootstrap exemption -- it runs before any signing key is
+  registered and so is not signature-verified -- while every other method
+  must present a verifiable signature.
+- **Signed-request key revocation can no longer be bypassed by backdating
+  (`security-signed/1.0`, both implementations).** Signature verification
+  previously selected the key and evaluated revocation using the envelope's
+  own `ts`, which the signer controls; a holder of a revoked key could set
+  `ts` to before the revocation and still be accepted. Revocation is now
+  evaluated against the coordinator's trusted clock, so a revoked key is
+  rejected for any live request regardless of the claimed `ts`. (Historical
+  verification against the validity window still uses `ts`.)
+- **Audit chain verification now detects tampering of every entry
+  (`audit.verify_chain`, both implementations).** Two flaws previously let
+  a modified chain pass verification: the replayed chain head was never
+  compared against the stored `chain_head` (so tampering the final entry,
+  which no stored `prev_hash` covers, went undetected), and an entry could
+  opt out of its own check by dropping its `prev_hash`. Verification now
+  recomputes every link, requires each stored `prev_hash` to match, and
+  compares the replayed head to the stored head. This closes a
+  tamper-evidence gap in the audit chain. Verification is scoped to the
+  chained region: leading un-chained entries (from before chaining was
+  enabled on the workspace) are skipped, and verifying a workspace with no
+  chain enabled returns a clear error rather than a false pass.
+- **JSON Patch prototype-pollution fix (TypeScript).** A crafted
+  `decide.override` diff with a path through `__proto__`, `constructor`, or
+  `prototype` could pollute `Object.prototype` in the coordinator process.
+  Both implementations now reject those path segments. Since an override
+  diff comes from a reviewer, this closes an injection vector reachable
+  from ordinary protocol input.
+- **Internal errors no longer echo raw exception text on the wire.** The
+  JSON-RPC internal-error response (`-32603`) previously included the raw
+  exception message, which could disclose internal detail to callers. The
+  wire message is now generic; specifics are carried in the error `data`
+  field for operators.
+
+### Packaging
+
+- Publish-readiness fixes across all packages: author contact set to
+  `oss@brightbeam.com`; an Apache-2.0 `LICENSE` file added to every
+  package; the SPDX `license` expression adopted (deprecated classifier
+  removed); package `__version__` now derives from installed metadata
+  instead of a hardcoded string that had drifted; the npm scope is
+  `@brightbeamai`; bridge READMEs and dependency pins corrected.
+- The four newer bridges are wired for release the same way
+  `chap-langgraph` is [pending: see the release-workflow decision]. Any
+  bridge not yet published to PyPI ships as source in the repo and runs
+  from a clone.
+
+### Tests
+
+- New bridge suites, all green against the coordinator with authorisation
+  enforcement: `chap-pydantic-ai` 17, `chap-ag2` 14, `chap-llama-index` 13,
+  `chap-google-adk` 15.
+- New cross-implementation conformance suites for canonicalisation and JSON
+  Patch, asserting byte-identical output and matching rejection between the
+  Python and TypeScript references.
+- TypeScript coordinator 103, MCP 17, A2A 14, playground 7; Python
+  coordinator 172, langgraph 10. Conformance harness 23/23 on both
+  reference implementations.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ incremented under the same rules.
 
 ## Unreleased
 
+### Unreleased features are marked as such
+
+`main` documents `approved_artefact_digest`, the open-review guard, and error
+codes `-32014` and `-32074` across five documents. None of them exist in any
+published package: the newest release is 0.2.9, which predates all of it. A
+reader following the specification while running the published packages would
+have found the behaviour missing and had no way to tell why.
+
+Those sections now carry an explicit unreleased marker, including the
+conformance vectors `rv-09` to `rv-11`, which a coordinator built from 0.2.9
+cannot pass and should not be expected to. The markers come out when the work
+ships.
+
 ### Documentation consistency
 
 - **The 0.2.7 changelog section is restored.** 218 lines covering the four

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,16 +48,16 @@ before publishing.
 |-----------------------------------|--------------------------------------------------------|
 | Typo or editorial fix             | Pull request directly                                  |
 | New worked example                | Pull request directly                                  |
-| New transport binding             | RFC-style proposal (see below)                         |
-| New method or namespace           | RFC-style proposal (see below)                         |
-| Breaking change to envelope or identity | RFC-style proposal + working-group review          |
+| New transport binding             | CEP (see below)                                        |
+| New method or namespace           | CEP (see below)                                        |
+| Breaking change to envelope or identity | CEP + working-group review                         |
 | Security-sensitive change         | See [SECURITY.md](./SECURITY.md), do not open public issue |
 | New conformance test vector       | Pull request directly                                  |
 | New integration document          | Pull request directly                                  |
 
 ---
 
-## 2. Proposal format ("CHAP Improvement Proposals")
+## 2. Proposal format: CHAP Enhancement Proposals (CEPs)
 
 For substantive changes, write a proposal that includes:
 
@@ -68,6 +68,11 @@ For substantive changes, write a proposal that includes:
 5. **Security considerations.** Threat impact, key-handling impact.
 6. **Alternatives considered.** Why this design over the alternatives?
 7. **Open questions.**
+
+Submit a CEP as a pull request adding `ceps/CEP-NNN.md`; the Editor assigns
+the number. [`ceps/CEP-001.md`](./ceps/CEP-001.md) is a worked example, and
+[`GOVERNANCE.md`](./GOVERNANCE.md) §3.2 defines the required sections and the
+public comment period.
 
 Proposals are reviewed in a public forum and require **rough consensus**
 of the working group before they merge into a draft.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,52 @@
+# Maintainers
+
+Referenced by [`GOVERNANCE.md`](./GOVERNANCE.md) §2.1,
+[`SECURITY.md`](./SECURITY.md) §7 and
+[`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md).
+
+## Current state
+
+CHAP 0.2 is a public draft maintained by two people.
+
+Arsalan Shahid and Bogdan Castraveti maintain the specification, schemas and
+reference implementations, review and merge changes, and run releases.
+
+**Arsalan Shahid takes responsibility for protocol decisions.** Where a change
+alters the wire format, the state machine, or the meaning of an existing
+field, the decision is his.
+
+[`GOVERNANCE.md`](./GOVERNANCE.md) §2 describes a structure with Editors
+implementing consensus, a Steering Committee ratifying decisions, and Working
+Groups. That is the intended structure for standards-track promotion, not a
+description of today: no Steering Committee is constituted and no Working
+Group is active. Where the two documents differ, this one describes the
+present.
+
+This mirrors the position [`SPECIFICATION.md`](./SPECIFICATION.md) §1 takes on
+conformance: the draft is usable and honest about what it is not yet.
+
+## Maintainers
+
+These are the Editors that [`GOVERNANCE.md`](./GOVERNANCE.md) §2.1 refers to.
+
+| Name | Contact | GitHub | Role |
+|------|---------|--------|------|
+| Arsalan Shahid | arsalan.shahid@brightbeam.com | [@brightbeamarsalan](https://github.com/brightbeamarsalan) | Maintainer; protocol decisions |
+| Bogdan Castraveti | bogdan.castraveti@brightbeam.com | [@BrightbeamBogdanCastraveti](https://github.com/BrightbeamBogdanCastraveti) | Maintainer |
+
+## Contributors
+
+CHAP is co-authored with Gordon Suttie and Philip Black.
+
+Contributions of any size are welcome; see
+[`CONTRIBUTING.md`](./CONTRIBUTING.md). Anyone who files an issue, opens a
+pull request, or joins a discussion is a contributor
+([`GOVERNANCE.md`](./GOVERNANCE.md) §2.4).
+
+## Security contact
+
+Report vulnerabilities through **private vulnerability reporting** on this
+repository, under the Security tab. Do not open a public issue.
+[`SECURITY.md`](./SECURITY.md) §7 sets out the disclosure timeline.
+
+For anything else: oss@brightbeam.com

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -643,8 +643,8 @@ Transitions are triggered by methods:
 | accepted           | `task.start`                  | in_progress       |
 | in_progress        | `task.complete`               | completed         |
 | in_progress        | `review.request`              | review_requested  |
-| review_requested   | `review.request` (same artefact) | review_requested (reviewer set widened) |
-| review_requested   | `review.request` (different artefact) | refused, -32014 |
+| review_requested   | `review.request` (same artefact) | review_requested (reviewer set widened). **Unreleased** |
+| review_requested   | `review.request` (different artefact) | refused, -32014. **Unreleased** |
 | review_requested   | `decide.approve`              | completed         |
 | review_requested   | `decide.reject`               | (back to in_progress or declined per policy) |
 | review_requested   | `decide.override`             | completed (with override artefact) |

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1236,45 +1236,56 @@ Error responses carry an `error` object:
 
 Error codes follow JSON-RPC conventions with CHAP-specific extensions:
 
-| Range              | Meaning                                          |
-|--------------------|--------------------------------------------------|
-| -32700             | Parse error                                      |
-| -32600 to -32603   | JSON-RPC standard errors                         |
-| -32400 to -32499   | CHAP envelope and identity errors                 |
-| -32500 to -32599   | CHAP policy and mode errors                       |
-| -32600 to -32699   | CHAP task and lifecycle errors                    |
-| -32700 to -32799   | CHAP evidence and audit errors                    |
-| -32800 to -32899   | CHAP composition errors (MCP/A2A bridge)          |
-| -32900 to -32999   | Implementation-defined                           |
+| Range                      | Meaning                                     |
+|----------------------------|---------------------------------------------|
+| -32700, -32600 to -32603   | JSON-RPC 2.0 standard errors                |
+| -32010 to -32099           | Profile errors, one decade per profile      |
+| -32400 to -32499           | Identity profile errors                     |
+| -32500 to -32599           | Routing and policy errors                   |
+| -32900 to -32999           | Implementation-defined                      |
+
+The JSON-RPC band is fixed by that specification and CHAP does not reuse it.
+Each profile owns one decade, so a code identifies its profile on sight:
+
+| Decade   | Profile              | Decade   | Profile              |
+|----------|----------------------|----------|----------------------|
+| -3201x   | `review/1.0`         | -3206x   | `control/1.0`        |
+| -3202x   | `whisper/1.0`        | -3207x   | `security-signed/1.0`|
+| -3203x   | `deliberation/1.0`   | -3208x   | `audit-scitt/1.0`    |
+| -3204x   | `modes/1.0`          | -3240x   | `identity-oidc/1.0`  |
+| -3205x   | `handoff/1.0`        | -3241x   | `identity-vc/1.0`    |
+|          |                      | -3251x   | `routing/1.0`        |
 
 ### 13.3 Standard error codes
 
-| Code   | Symbol                          | Meaning                                              |
-|--------|---------------------------------|------------------------------------------------------|
-| -32700 | `parse_error`                   | Invalid JSON.                                        |
-| -32600 | `invalid_request`               | Envelope does not conform to schema.                 |
-| -32601 | `method_not_found`              | Unknown method name.                                 |
-| -32602 | `invalid_params`                | Params do not conform to method schema.              |
-| -32603 | `internal_error`                | Implementation defect.                               |
-| -32400 | `signature_invalid`             | Signature failed verification.                       |
-| -32401 | `temporal_order_violation`      | Non-monotonic timestamp from origin.                 |
-| -32402 | `step_up_required`              | Privileged op without recent auth.                   |
-| -32403 | `unknown_participant`           | `from` or `to` is not a workspace member.            |
-| -32404 | `key_revoked`                   | Signing key has been revoked.                        |
-| -32405 | `version_unsupported`           | `chap` version not recognised.                        |
-| -32500 | `policy_denied`                 | Caller's role does not permit the method.            |
-| -32040 | `mode_ceiling_exceeded`         | Task mode exceeds workspace ceiling.                 |
-| -32502 | `scope_missing`                 | Recipient has not declared the required scope.       |
-| -32600 | `task_state_invalid`            | Method illegal in task's current state.              |
-| -32601 | `review_rule_unmet`             | Decision cannot terminate the review under the rule. |
-| -32602 | `deadline_exceeded`             | Operation arrived after the task deadline.           |
-| -32700 | `evidence_break`                | `prev_hash` does not match chain head.               |
-| -32701 | `id_reused`                     | `id` already present in chain.                       |
-| -32800 | `mcp_tool_failed`               | Cited MCP tool invocation reported failure.          |
-| -32801 | `a2a_peer_unreachable`          | Bridge to an A2A peer failed.                        |
+The five JSON-RPC 2.0 codes carry their standard meanings:
 
-Implementations MUST use these codes for the stated conditions and
-MAY define implementation-specific codes in the -32900 range.
+| Code   | Symbol             | Meaning                                     |
+|--------|--------------------|---------------------------------------------|
+| -32700 | `parse_error`      | Invalid JSON.                               |
+| -32600 | `invalid_request`  | Envelope does not conform to schema.        |
+| -32601 | `method_not_found` | Unknown method name.                        |
+| -32602 | `invalid_params`   | Params do not conform to the method schema. |
+| -32603 | `internal_error`   | Implementation defect.                      |
+
+Every other code belongs to the profile that defines it, and **each
+profile's own error table is authoritative**: `profiles/review.md` §5,
+`profiles/whisper.md` §6, `profiles/deliberation.md` §5,
+`profiles/modes.md` §6, `profiles/handoff.md` §6, `profiles/control.md` §6,
+`profiles/security-signed.md` §7, `profiles/audit-scitt.md` §8,
+`profiles/identity-oidc.md` §8, `profiles/identity-vc.md` §8, and
+`profiles/routing.md` §3 to §5. The decade map in §13.2 says which profile a
+code belongs to.
+
+Codes are not restated here. A duplicated registry drifts from the profiles
+it mirrors, which is what happened to the table this section replaces: it
+assigned `-32600`, `-32601` and `-32602` two meanings each, gave
+`mode_ceiling_exceeded` a code no implementation used, and named errors that
+neither reference implementation has ever returned.
+
+Implementations MUST use the codes their profiles define, MUST NOT reuse the
+JSON-RPC band, and MAY define implementation-specific codes in the -32900
+range.
 
 ---
 

--- a/conformance/harness/package.json
+++ b/conformance/harness/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@brightbeamai/conformance-harness",
   "version": "1.0.0",
-  "description": "CHAP conformance test harness — runs canonical vectors against any CHAP endpoint.",
+  "description": "CHAP conformance test harness: runs canonical vectors against any CHAP endpoint.",
   "license": "Apache-2.0",
   "type": "module",
   "private": true,

--- a/conformance/test-vectors.md
+++ b/conformance/test-vectors.md
@@ -105,6 +105,10 @@ differs but the bytes look almost right, check (in order):
 
 ---
 
+> **Unreleased.** These three vectors exercise behaviour on `main` that is
+> not in a published release. A coordinator built from 0.2.9 will not pass
+> them, and should not be expected to.
+
 ## 2a. Binding a decision to its content (CEP-001)
 
 Three vectors cover the artefact digest and the open-review guard. They are

--- a/docs/casts/hero.tape
+++ b/docs/casts/hero.tape
@@ -1,4 +1,4 @@
-# hero.tape — generates docs/img/hero.gif
+# hero.tape, generates docs/img/hero.gif
 #
 # This drives the CHAP playground demo and records a ~30s walkthrough
 # showing: agent drafts -> human overrides -> chain replays.

--- a/packages/coordinator/tests/restore_corrupt_row.test.ts
+++ b/packages/coordinator/tests/restore_corrupt_row.test.ts
@@ -5,15 +5,27 @@
  */
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
+import { createRequire } from "node:module";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+// Same fault as tests/storage.test.ts had: `require` is undefined under
+// `tsx --test`, so the ReferenceError was caught and read as "driver
+// missing", skipping this suite on every machine. Opening a database is the
+// real probe, since the wrapper resolves even with no native bindings.
+const require_ = createRequire(import.meta.url);
 let sqliteAvailable = true;
+let sqliteError = "";
 try {
-  require("better-sqlite3");
-} catch {
+  const Probe = require_("better-sqlite3");
+  new Probe(":memory:").close();
+} catch (e) {
   sqliteAvailable = false;
+  sqliteError = e instanceof Error ? e.message.split("\n")[0] : String(e);
+}
+if (!sqliteAvailable && process.env.CHAP_REQUIRE_SQLITE) {
+  throw new Error(`better-sqlite3 is required when CHAP_REQUIRE_SQLITE is set: ${sqliteError}`);
 }
 
 describe("SqliteStore corrupt-row recovery", { skip: !sqliteAvailable }, () => {
@@ -24,7 +36,7 @@ describe("SqliteStore corrupt-row recovery", { skip: !sqliteAvailable }, () => {
     for (const w of ["w1", "w2", "w3"]) {
       store.save({ id: w, data: { id: w }, version: 1, updated_at: "t" });
     }
-    const Database = require("better-sqlite3");
+    const Database = require_("better-sqlite3");
     const raw = new Database(join(tmp, "c.db"));
     raw.prepare("UPDATE chap_workspaces SET data = ? WHERE id = ?").run("{bad json", "w2");
     raw.close();

--- a/packages/coordinator/tests/storage.test.ts
+++ b/packages/coordinator/tests/storage.test.ts
@@ -96,7 +96,7 @@ describe("Coordinator persistence", () => {
 
 // ---- SqliteStore (skipped if better-sqlite3 unavailable) -----------
 
-// `require` is not defined under `tsx --test`, so a bare require() here threw
+// A bare `require` is not defined under `tsx --test`, so the old probe threw
 // ReferenceError and the catch marked SQLite unavailable on every machine,
 // silently skipping these suites forever. createRequire is the ESM-correct
 // probe. CHAP_REQUIRE_SQLITE makes an unavailable driver a failure rather than

--- a/profiles/identity-vc.md
+++ b/profiles/identity-vc.md
@@ -153,10 +153,21 @@ from the workspace.
 | Code      | Meaning                                                |
 |-----------|--------------------------------------------------------|
 | `-32410`  | VP signature verification failed.                      |
-| `-32411`  | VC issuer not trusted by this workspace.               |
+| `-32411`  | Holder binding (proof of possession) failed.           |
 | `-32412`  | VC has been revoked.                                   |
-| `-32413`  | Required credential claim not disclosed.               |
-| `-32414`  | Holder binding (proof of possession) failed.           |
+| `-32413`  | Credential schema not recognised by this workspace.    |
+
+Two further conditions are described by this profile but are **not yet
+implemented** by either reference implementation, so no code is assigned:
+an issuer the workspace does not trust, and a required credential claim
+that was not disclosed. Implementations encountering them today reject the
+presentation as invalid (`-32410`). Assigning codes is left to a revision of
+this profile.
+
+Earlier drafts of this table assigned -32411 to issuer trust, -32413 to
+claim disclosure, and -32414 to holder binding. No implementation ever
+used that mapping; the table above is what both reference coordinators
+return.
 
 ---
 

--- a/profiles/review.md
+++ b/profiles/review.md
@@ -71,6 +71,10 @@ task whose `review.required` was true.
 Supported `rule` values: `any_one_approves`, `all_approve`.
 The `deliberation` profile adds richer rules (`quorum:N`, weighted).
 
+> **Unreleased.** Implemented on `main` and not in a published release.
+> The newest published packages are 0.2.9, which predate it. See
+> [`ceps/CEP-001.md`](../ceps/CEP-001.md).
+
 **Re-request on an open review.** A review already open on the task
 constrains what a second `review.request` may do.
 
@@ -96,6 +100,10 @@ constrains what a second `review.request` may do.
 
 Straightforward. The reviewer's identity, comment, and tags are
 preserved as a `decision` artefact.
+
+> **Unreleased.** Implemented on `main` and not in a published release.
+> The newest published packages are 0.2.9, which predate it. See
+> [`ceps/CEP-001.md`](../ceps/CEP-001.md).
 
 **Binding the decision to the content (`approved_artefact_digest`).**
 A decision names `task_id`, which identifies *which* review it settles
@@ -343,7 +351,7 @@ piece of the protocol is plumbing.
 | `-32011`  | Actor is not authorised: not a workspace member, or a member who was not an addressed reviewer for this task. |
 | `-32012`  | JSON Patch application failed (with path in `data`).   |
 | `-32013`  | Review deadline has lapsed.                            |
-| `-32014`  | A review is already open on this task with different content, or the request would change the decision rule of an open review. |
+| `-32014`  | A review is already open on this task with different content, or the request would change the decision rule of an open review. **Unreleased.** |
 
 ---
 

--- a/profiles/security-signed.md
+++ b/profiles/security-signed.md
@@ -166,7 +166,7 @@ the revocation. Messages dated after are rejected with `-32070`.
 | `-32071`  | No known key matching `from` + `kid` + `ts`.     |
 | `-32072`  | Key has been revoked.                            |
 | `-32073`  | Rotation message not signed with old key.        |
-| `-32074`  | `approved_artefact_digest` does not match the artefact under review. |
+| `-32074`  | `approved_artefact_digest` does not match the artefact under review. **Unreleased.** |
 
 ---
 

--- a/reference/playground/src/public/index.html
+++ b/reference/playground/src/public/index.html
@@ -24,10 +24,10 @@
 </header>
 
 <!-- =========================================================
-     STATUS BAR — always visible once in a role; protocol heartbeat
+     STATUS BAR, always visible once in a role; protocol heartbeat
      ========================================================= -->
 <div class="statusbar" id="statusbar" hidden>
-  <div class="status-item" title="Workspace mode — affects whether bot output reaches customers">
+  <div class="status-item" title="Workspace mode, affects whether bot output reaches customers">
     <span class="status-label">Mode</span>
     <span class="status-value mode-pill mode-production" id="status-mode">production</span>
   </div>
@@ -76,7 +76,7 @@
     <div class="picker-tour-offer">
       <div class="picker-tour-text">
         <strong>First time here?</strong>
-        Take a 90-second guided walkthrough — the protocol drives itself
+        Take a 90-second guided walkthrough, the protocol drives itself
         through one full ticket and explains each step as it happens.
       </div>
       <button class="picker-tour-btn" id="start-walkthrough">Take the guided tour →</button>
@@ -122,7 +122,7 @@
       <div class="footer-block">
         <div class="footer-label">What's real</div>
         <ul>
-          <li>Real CHAP coordinator on localhost — protocol code is <span class="kbd">@brightbeamai/chap-coordinator</span></li>
+          <li>Real CHAP coordinator on localhost, protocol code is <span class="kbd">@brightbeamai/chap-coordinator</span></li>
           <li>Real Ollama-backed agent (<span class="kbd" id="model-label">gemma3:4b</span>)</li>
           <li>Real RFC 6902 JSON Patch on overrides</li>
           <li>Real evidence chain, persisted to disk</li>
@@ -140,7 +140,7 @@
   </section>
 
   <!-- =========================================================
-       MAYA's UI — front-line review queue
+       MAYA's UI, front-line review queue
        ========================================================= -->
   <section class="role-view" id="view-maya" hidden>
     <div class="role-view-grid">
@@ -159,7 +159,7 @@
           <p>Bot drafts will appear here as <span class="kbd">gemma3:4b</span> finishes them.</p>
         </div>
         <div id="maya-editor" hidden>
-          <!-- Guided tour bar — auto-dismisses after first override -->
+          <!-- Guided tour bar, auto-dismisses after first override -->
           <div class="tour-bar" id="maya-tour" data-step="1">
             <div class="tour-step-indicator">
               <span class="tour-dot active" data-step="1"></span>
@@ -167,7 +167,7 @@
               <span class="tour-dot" data-step="3"></span>
             </div>
             <div class="tour-text">
-              <span class="tour-step-text" data-step="1">← Read the ticket. The bot has drafted a reply below — read both before editing.</span>
+              <span class="tour-step-text" data-step="1">← Read the ticket. The bot has drafted a reply below, read both before editing.</span>
               <span class="tour-step-text" data-step="2" hidden>Now edit the draft. The diff is computed live and shown under the textarea.</span>
               <span class="tour-step-text" data-step="3" hidden>Pick at least one tag, write a brief rationale, then click <strong>Override &amp; send</strong>. The override becomes a signed envelope on the chain.</span>
             </div>
@@ -182,8 +182,8 @@
             </div>
             <div class="ticket-badges">
               <span class="badge" id="maya-crit-badge">criticality</span>
-              <span class="badge badge-confidence" id="maya-conf-badge">conf —</span>
-              <span class="badge badge-model" id="maya-model-badge">model —</span>
+              <span class="badge badge-confidence" id="maya-conf-badge">conf -</span>
+              <span class="badge badge-model" id="maya-model-badge">model -</span>
             </div>
           </header>
 
@@ -200,18 +200,18 @@
 
           <div class="override-meta">
             <label>
-              <span>Tags <small class="meta-help">— what kind of correction is this?</small></span>
+              <span>Tags <small class="meta-help">- what kind of correction is this?</small></span>
               <div class="tag-picker" id="maya-tags">
                 <button data-tag="tone-softened"      title="Bot was too harsh or too apologetic for the situation">tone-softened</button>
-                <button data-tag="severity-upgraded"  title="Bot under-classified — this is more urgent than it judged">severity-upgraded</button>
-                <button data-tag="severity-downgraded" title="Bot over-classified — this is less urgent than it judged">severity-downgraded</button>
+                <button data-tag="severity-upgraded"  title="Bot under-classified, this is more urgent than it judged">severity-upgraded</button>
+                <button data-tag="severity-downgraded" title="Bot over-classified, this is less urgent than it judged">severity-downgraded</button>
                 <button data-tag="factual-fix"        title="Bot invented or got a fact wrong (policy, dates, numbers)">factual-fix</button>
                 <button data-tag="length-reduced"     title="Bot was too long-winded; cut to essentials">length-reduced</button>
                 <button data-tag="scope-redirected"   title="Bot tried to help with something out-of-scope; redirected">scope-redirected</button>
               </div>
             </label>
             <label>
-              <span>Rationale <small class="meta-help">— required; this is what teaches the bot</small></span>
+              <span>Rationale <small class="meta-help">- required; this is what teaches the bot</small></span>
               <textarea class="rationale-input" id="maya-rationale" rows="2" placeholder="Why this change? (required for override)"></textarea>
             </label>
           </div>
@@ -234,7 +234,7 @@
             <p><strong>What is this?</strong></p>
             <p>Each time you override the bot, your tags accumulate here. After enough overrides, this becomes a tuning signal: <em>which kinds of mistakes does the bot make most?</em></p>
             <p class="dividend-empty-counter">
-              <span id="maya-dividend-progress">0 / 2</span> overrides — chart appears after 2.
+              <span id="maya-dividend-progress">0 / 2</span> overrides, chart appears after 2.
             </p>
           </div>
           <div class="dividend-chart" id="maya-dividend" hidden></div>
@@ -244,7 +244,7 @@
   </section>
 
   <!-- =========================================================
-       SAM's UI — escalation queue
+       SAM's UI, escalation queue
        ========================================================= -->
   <section class="role-view" id="view-sam" hidden>
     <div class="role-view-grid">
@@ -262,12 +262,12 @@
           <h2>Nothing escalated yet.</h2>
           <p>
             Items appear here automatically when the routing policy decides they
-            need senior eyes — <span class="kbd">criticality=critical</span>, or
+            need senior eyes, <span class="kbd">criticality=critical</span>, or
             <span class="kbd">criticality=high</span> with bot confidence under 0.6.
           </p>
         </div>
         <div id="sam-editor" hidden>
-          <!-- Guided tour bar for Sam — auto-dismisses after first action -->
+          <!-- Guided tour bar for Sam, auto-dismisses after first action -->
           <div class="tour-bar" id="sam-tour" data-step="1">
             <div class="tour-step-indicator">
               <span class="tour-dot active" data-step="1"></span>
@@ -312,18 +312,18 @@
 
           <div class="override-meta">
             <label>
-              <span>Tags <small class="meta-help">— Sam-level: policy, legal, retention, fraud signals</small></span>
+              <span>Tags <small class="meta-help">- Sam-level: policy, legal, retention, fraud signals</small></span>
               <div class="tag-picker" id="sam-tags">
                 <button data-tag="policy-clarification" title="Clarifies a company policy that wasn't applied correctly">policy-clarification</button>
                 <button data-tag="legal-review-needed"  title="This needs legal sign-off before going out">legal-review-needed</button>
                 <button data-tag="commit-authority"     title="Sam has the authority to commit (refunds, credits, exceptions); Maya doesn't">commit-authority</button>
                 <button data-tag="customer-retention"   title="Customer is at risk of churning; intervene to keep them">customer-retention</button>
-                <button data-tag="fraud-confirmed"      title="This is fraud — handle accordingly, not as customer service">fraud-confirmed</button>
-                <button data-tag="maya-undershot"       title="Maya's revision didn't go far enough — Sam strengthens it">maya-undershot</button>
+                <button data-tag="fraud-confirmed"      title="This is fraud, handle accordingly, not as customer service">fraud-confirmed</button>
+                <button data-tag="maya-undershot"       title="Maya's revision didn't go far enough, Sam strengthens it">maya-undershot</button>
               </div>
             </label>
             <label>
-              <span>Rationale <small class="meta-help">— required if overriding Maya's revision</small></span>
+              <span>Rationale <small class="meta-help">- required if overriding Maya's revision</small></span>
               <textarea class="rationale-input" id="sam-rationale" rows="2" placeholder="Required if overriding Maya's revision"></textarea>
             </label>
           </div>
@@ -344,9 +344,9 @@
         <div class="pane-body">
           <div class="dividend-empty" id="sam-dividend-empty">
             <p><strong>What is this?</strong></p>
-            <p>When you override Maya's revision, your tags accumulate here. The pattern reveals what front-line review consistently misses — that's where to update training, policy, or staffing.</p>
+            <p>When you override Maya's revision, your tags accumulate here. The pattern reveals what front-line review consistently misses, that's where to update training, policy, or staffing.</p>
             <p class="dividend-empty-counter">
-              <span id="sam-dividend-progress">0 / 2</span> overrides — chart appears after 2.
+              <span id="sam-dividend-progress">0 / 2</span> overrides, chart appears after 2.
             </p>
           </div>
           <div class="dividend-chart" id="sam-dividend" hidden></div>
@@ -358,14 +358,14 @@
 </main>
 
 <!-- =========================================================
-     WIRE STRIP — collapsed-by-default ticker at the bottom of the
+     WIRE STRIP, collapsed-by-default ticker at the bottom of the
      viewport. Click to expand into the full chain view.
      ========================================================= -->
 <aside class="wire-strip" id="wire-strip" hidden>
   <div class="wire-strip-pill" id="wire-strip-pill">
     <span class="wire-strip-label">Last envelope</span>
-    <span class="wire-strip-seq" id="wire-strip-seq">—</span>
-    <span class="wire-strip-method" id="wire-strip-method">—</span>
+    <span class="wire-strip-seq" id="wire-strip-seq">-</span>
+    <span class="wire-strip-method" id="wire-strip-method">-</span>
     <span class="wire-strip-spacer"></span>
     <span class="wire-strip-cta">Click to open chain view ↑</span>
   </div>
@@ -393,7 +393,7 @@
 </aside>
 
 <!-- =========================================================
-     WALKTHROUGH PANEL — the guided 90-second tour. Hidden by default.
+     WALKTHROUGH PANEL, the guided 90-second tour. Hidden by default.
      Steps are fired from playground.js. The protocol is driven for real.
      ========================================================= -->
 <aside class="walkthrough" id="walkthrough" hidden>
@@ -421,7 +421,7 @@
   </div>
 </aside>
 
-<!-- Glow highlight overlay — positioned absolutely over a target element -->
+<!-- Glow highlight overlay, positioned absolutely over a target element -->
 <div class="glow-target" id="glow-target" hidden></div>
 
 <script src="/playground.js"></script>

--- a/reference/playground/src/public/playground.css
+++ b/reference/playground/src/public/playground.css
@@ -1,4 +1,4 @@
-/* CHAP Playground — Brightbeam brand styling.
+/* CHAP Playground, Brightbeam brand styling.
    Tokens match demo/index.html so the two pages feel cohesive.
 */
 
@@ -176,7 +176,7 @@ button {
 .footer-block li { margin: 3px 0; }
 
 /* ============================================================
-   ROLE VIEWS — three-column layout
+   ROLE VIEWS, three-column layout
    ============================================================ */
 .role-view { max-width: 1500px; margin: 0 auto; padding: 22px; }
 .role-view-grid {
@@ -398,10 +398,10 @@ button {
 /* ============================================================
    WIRE PANEL
    ============================================================ */
-/* Wire panel — see v2 section below for the canonical styles. */
+/* Wire panel, see v2 section below for the canonical styles. */
 
 /* ====================================================================
-   v2 IMPROVEMENTS — status bar, tour, chain view, strip, dividend prog.
+   v2 IMPROVEMENTS, status bar, tour, chain view, strip, dividend prog.
    ==================================================================== */
 
 /* -------- Status bar (under topbar, always visible in a role) ------ */
@@ -598,7 +598,7 @@ button {
   100% { background: var(--black); }
 }
 
-/* -------- Wire panel (expanded chain view) — overrides earlier rules */
+/* -------- Wire panel (expanded chain view), overrides earlier rules */
 .wire-panel {
   position: fixed;
   left: 0;
@@ -692,7 +692,7 @@ button {
   background: #1a1a1c;
 }
 
-/* Restructured wire entry — chain visualisation */
+/* Restructured wire entry, chain visualisation */
 .wire-entry {
   background: #232325;
   border-left: 3px solid var(--grey-2);
@@ -790,7 +790,7 @@ button {
 .wire-entry:hover .wire-hash { display: block; }
 
 /* ====================================================================
-   GUIDED WALKTHROUGH — floating panel, glow highlights, role-picker CTA
+   GUIDED WALKTHROUGH, floating panel, glow highlights, role-picker CTA
    ==================================================================== */
 
 /* -------- Role-picker tour offer ---------------------------------- */

--- a/reference/playground/src/public/playground.js
+++ b/reference/playground/src/public/playground.js
@@ -1,5 +1,5 @@
 /**
- * CHAP Playground — browser client.
+ * CHAP Playground, browser client.
  *
  * Every user action becomes a real JSON-RPC envelope sent to POST /rpc.
  * The server's coordinator processes it, appends it to the evidence
@@ -141,7 +141,7 @@ function startSse() {
 }
 
 // ============================================================
-//   RFC 6902 JSON Patch — compute diff in the browser
+//   RFC 6902 JSON Patch, compute diff in the browser
 //   (mirrors packages/coordinator/src/patch.ts diffJsonPatch)
 // ============================================================
 function diffJsonPatch(from, to, basePath = "") {
@@ -242,9 +242,9 @@ function renderMaya() {
   list.innerHTML = "";
   for (const t of queue) {
     const selected = t.id === state.selectedTaskId;
-    const ticketId = t.input?.ticket_id ?? "—";
+    const ticketId = t.input?.ticket_id ?? "-";
     const subject = t.input?.subject ?? t.kind;
-    const crit = t.routing_hints?.criticality ?? "—";
+    const crit = t.routing_hints?.criticality ?? "-";
     const item = el("div", { class: `queue-item${selected ? " selected" : ""}`,
                             onclick: () => selectTask(t.id) },
       el("div", { class: "queue-item-id" }, ticketId),
@@ -283,21 +283,21 @@ function renderMayaEditor(task) {
   $("maya-empty").hidden  = true;
   $("maya-editor").hidden = false;
 
-  const ticketId = task.input?.ticket_id ?? "—";
+  const ticketId = task.input?.ticket_id ?? "-";
   $("maya-ticket-id").textContent = ticketId;
   $("maya-ticket-subject").textContent = task.input?.subject ?? "";
-  $("maya-ticket-from").textContent = `from ${task.input?.customer ?? "—"}`;
+  $("maya-ticket-from").textContent = `from ${task.input?.customer ?? "-"}`;
   $("maya-ticket-body").textContent = task.input?.body ?? "";
 
-  const crit = task.routing_hints?.criticality ?? "—";
+  const crit = task.routing_hints?.criticality ?? "-";
   const critBadge = $("maya-crit-badge");
   critBadge.textContent = `criticality: ${crit}`;
   critBadge.className   = `badge badge-crit-${crit}`;
 
   const conf = task.artefact_routing_hints?.confidence;
-  $("maya-conf-badge").textContent = `conf ${typeof conf === "number" ? conf.toFixed(2) : "—"}`;
+  $("maya-conf-badge").textContent = `conf ${typeof conf === "number" ? conf.toFixed(2) : "-"}`;
 
-  const modelId = task.artefact_routing_hints?.model_id ?? "—";
+  const modelId = task.artefact_routing_hints?.model_id ?? "-";
   $("maya-model-badge").textContent = `model ${modelId}`;
 
   const escalateBtn = $("maya-escalate");
@@ -350,9 +350,9 @@ function renderSam() {
   list.innerHTML = "";
   for (const t of queue) {
     const selected = t.id === state.selectedTaskId;
-    const ticketId = t.input?.ticket_id ?? "—";
+    const ticketId = t.input?.ticket_id ?? "-";
     const subject = t.input?.subject ?? t.kind;
-    const crit = t.routing_hints?.criticality ?? "—";
+    const crit = t.routing_hints?.criticality ?? "-";
     const item = el("div", { class: `queue-item${selected ? " selected" : ""}`,
                             onclick: () => selectTask(t.id) },
       el("div", { class: "queue-item-id" }, ticketId),
@@ -382,13 +382,13 @@ function renderSamEditor(task) {
   $("sam-empty").hidden  = true;
   $("sam-editor").hidden = false;
 
-  const ticketId = task.input?.ticket_id ?? "—";
+  const ticketId = task.input?.ticket_id ?? "-";
   $("sam-ticket-id").textContent = ticketId;
   $("sam-ticket-subject").textContent = task.input?.subject ?? "";
-  $("sam-ticket-from").textContent = `from ${task.input?.customer ?? "—"}`;
+  $("sam-ticket-from").textContent = `from ${task.input?.customer ?? "-"}`;
   $("sam-ticket-body").textContent = task.input?.body ?? "";
 
-  const crit = task.routing_hints?.criticality ?? "—";
+  const crit = task.routing_hints?.criticality ?? "-";
   const critBadge = $("sam-crit-badge");
   critBadge.textContent = `criticality: ${crit}`;
   critBadge.className   = `badge badge-crit-${crit}`;
@@ -487,7 +487,7 @@ async function sendOverride(role) {
     diff:         ops,
     rationale,
     tags,
-    // CHAP 0.2.1 — surface the new artefact-identity fields. The
+    // CHAP 0.2.1, surface the new artefact-identity fields. The
     // playground uses the task id as the durable logical handle (one
     // logical artefact per task) and defaults intent_preserved to true
     // because the UI is set up for tone/severity tone-tweak overrides,
@@ -588,7 +588,7 @@ function renderDividend(role) {
 }
 
 // ============================================================
-//   Wire panel — chain-style with routing/override classification
+//   Wire panel, chain-style with routing/override classification
 // ============================================================
 
 /** Classify a method name into one of: 'routing' | 'override' | 'default'. */
@@ -613,7 +613,7 @@ function summariseEnvelope(env) {
   }
   if (m === "task.complete" && p.routing_hints) {
     const c = p.routing_hints.confidence;
-    return c != null ? `confidence=${Number(c).toFixed(2)} · model=${p.routing_hints.model_id ?? "—"}` : "";
+    return c != null ? `confidence=${Number(c).toFixed(2)} · model=${p.routing_hints.model_id ?? "-"}` : "";
   }
   if (m === "decide.override") {
     const tags = Array.isArray(p.tags) ? p.tags.join(", ") : "";
@@ -688,7 +688,7 @@ function renderAllWireEntries() {
 }
 
 // ============================================================
-//   Status bar — mode pill, chain length, queue size, Ollama dot
+//   Status bar, mode pill, chain length, queue size, Ollama dot
 // ============================================================
 function updateStatusBar() {
   const ws = state.workspace;
@@ -752,7 +752,7 @@ async function pollHealth() {
 setInterval(() => { if (state.role) pollHealth(); }, 10000);
 
 // ============================================================
-//   Tour bar — guided 3-step walkthrough per role
+//   Tour bar, guided 3-step walkthrough per role
 // ============================================================
 function setTourStep(role, step) {
   if (role === "maya") state.mayaTourStep = step;
@@ -815,8 +815,8 @@ async function init() {
     state.wireEntries = [];
     state.lastChainLen = 0;
     $("wire-body").innerHTML = "";
-    $("wire-strip-seq").textContent = "—";
-    $("wire-strip-method").textContent = "—";
+    $("wire-strip-seq").textContent = "-";
+    $("wire-strip-method").textContent = "-";
     refreshWorkspace();
   });
 
@@ -896,7 +896,7 @@ async function init() {
 }
 
 // ============================================================
-//   GUIDED WALKTHROUGH — 6-step narrative tour
+//   GUIDED WALKTHROUGH, 6-step narrative tour
 //
 //   The walkthrough drives the protocol for real: it fires actual
 //   JSON-RPC envelopes against /rpc and watches them appear in the
@@ -919,7 +919,7 @@ const WALKTHROUGH_STEPS = [
 
   // ----------- Step 1: orient the user -----------
   {
-    title: "Welcome — this is a live CHAP workspace.",
+    title: "Welcome, this is a live CHAP workspace.",
     text: `
       <p>The bar at the top is the protocol's heartbeat. <em>Mode</em>
       tells you the workspace is in production. <em>Chain</em> counts
@@ -938,9 +938,9 @@ const WALKTHROUGH_STEPS = [
     title: "A ticket becomes a Task.",
     text: `
       <p>I just sent a <code>task.create</code> envelope on the wire.
-      The customer's question — <em>"where is my order?"</em> — is now
+      The customer's question, <em>"where is my order?"</em>, is now
       a structured Task with <code>routing_hints.criticality: low</code>.</p>
-      <p>Watch the protocol view at the bottom — the envelope landed at
+      <p>Watch the protocol view at the bottom, the envelope landed at
       the head of the chain. The whole audit trail starts here.</p>`,
     highlight: "#wire-panel",
     nextLabel: "Next: the bot drafts →",
@@ -956,7 +956,7 @@ const WALKTHROUGH_STEPS = [
       <p>The bot has completed the task. Its draft is now in Maya's
       queue (left), and it carried <em>measurement signals</em> back
       to the protocol: confidence, model_id, latency.</p>
-      <p>These aren't free text — they're typed fields in
+      <p>These aren't free text, they're typed fields in
       <code>Artefact.routing_hints</code>. The protocol will use them
       next.</p>`,
     highlight: "#maya-queue",
@@ -970,7 +970,7 @@ const WALKTHROUGH_STEPS = [
   {
     title: "Routing decisions fire automatically.",
     text: `
-      <p>Look at the protocol view below — two amber-bordered entries
+      <p>Look at the protocol view below, two amber-bordered entries
       just appeared on the chain: <code>review.depth</code> and
       <code>escalate.auto</code>. The routing policy read the hints
       and decided: low criticality + high confidence → spot-check; no
@@ -1005,7 +1005,7 @@ const WALKTHROUGH_STEPS = [
   {
     title: "Now a high-stakes ticket.",
     text: `
-      <p>I just fired a <em>second</em> ticket — an urgent fraud query
+      <p>I just fired a <em>second</em> ticket, an urgent fraud query
       with <code>criticality: critical</code>. Watch the wire panel:
       the routing policy auto-escalated to Sam without any human
       intervention.</p>
@@ -1014,7 +1014,7 @@ const WALKTHROUGH_STEPS = [
       <p><strong>That's CHAP.</strong> Wire format you can inspect,
       decisions you can audit, a chain you can prove.</p>`,
     highlight: "#wire-panel",
-    nextLabel: "Done — free play",
+    nextLabel: "Done, free play",
     auto: false,
     onEnter: () => walkthroughFireDemoTicket("INC-48224", "critical").then(() => {
       walkthroughCompleteAsBot("critical");
@@ -1023,7 +1023,7 @@ const WALKTHROUGH_STEPS = [
 ];
 
 async function walkthroughStart() {
-  // Make sure tickets are loaded — the walkthrough's step 2 needs to
+  // Make sure tickets are loaded, the walkthrough's step 2 needs to
   // look up the demo ticket by ID. If the user clicked fast before
   // init() finished, state.tickets might still be empty.
   if (!state.tickets || state.tickets.length === 0) {
@@ -1041,7 +1041,7 @@ async function walkthroughStart() {
     const ok = confirm(
       "The guided walkthrough works best from a clean workspace. " +
       "Reset the chain and tasks to start fresh? " +
-      "(Cancel to leave existing state alone — the walkthrough will still run, " +
+      "(Cancel to leave existing state alone, the walkthrough will still run, " +
       "but the wire will already be populated.)"
     );
     if (ok) {
@@ -1049,8 +1049,8 @@ async function walkthroughStart() {
       state.wireEntries = [];
       state.lastChainLen = 0;
       $("wire-body").innerHTML = "";
-      $("wire-strip-seq").textContent = "—";
-      $("wire-strip-method").textContent = "—";
+      $("wire-strip-seq").textContent = "-";
+      $("wire-strip-method").textContent = "-";
       await refreshWorkspace();
     }
   }
@@ -1194,7 +1194,7 @@ async function walkthroughFireDemoTicket(ticketId, criticality) {
     console.warn(`walkthrough: ticket ${ticketId} not found in state.tickets (length=${state.tickets.length})`);
     // Surface the failure to the user instead of silently advancing.
     $("walkthrough-text").innerHTML +=
-      `<p style="color:var(--ember-d); margin-top:8px;">⚠ Could not load ticket ${ticketId} — try clicking "↻ Guided tour" again after the page finishes loading.</p>`;
+      `<p style="color:var(--ember-d); margin-top:8px;">⚠ Could not load ticket ${ticketId}, try clicking "↻ Guided tour" again after the page finishes loading.</p>`;
     return;
   }
   const env = {
@@ -1230,7 +1230,7 @@ async function walkthroughFireDemoTicket(ticketId, criticality) {
 
 /**
  * Have "the bot" complete the most recent walkthrough task. This is
- * a stand-in for the Ollama agent — the walkthrough can't depend on a
+ * a stand-in for the Ollama agent, the walkthrough can't depend on a
  * model being installed, so we simulate the bot's task.complete with a
  * canned response. The protocol surface is identical to what the real
  * agent would emit.
@@ -1277,7 +1277,7 @@ async function walkthroughCompleteAsBot(criticality) {
 }
 
 /**
- * Hook from sendOverride — if the walkthrough is awaiting a user
+ * Hook from sendOverride, if the walkthrough is awaiting a user
  * override, this advances it to step 6.
  */
 function walkthroughOnUserOverride() {
@@ -1295,7 +1295,7 @@ init().catch((e) => console.error("init failed", e));
 window.addEventListener("error", (e) => {
   const msg = `${e.message} (${e.filename?.split("/").pop()}:${e.lineno})`;
   console.error("[playground]", e.error || e.message);
-  // Drop a one-line banner at top — non-intrusive but visible
+  // Drop a one-line banner at top, non-intrusive but visible
   if (!document.getElementById("err-banner")) {
     const b = document.createElement("div");
     b.id = "err-banner";

--- a/schemas/core/chap-task.schema.json
+++ b/schemas/core/chap-task.schema.json
@@ -162,7 +162,7 @@
         },
         "logical_id": {
           "type": "string",
-          "description": "Optional. Stable identifier for the thing the artefact is about — durable across revisions. Two artefacts that share a logical_id are two versions of the same underlying item. Producers SHOULD assign on first creation and reuse on every revision, override or supersession. CHAP itself reads only `id`; logical_id is for higher-layer version-graph projection.",
+          "description": "Optional. Stable identifier for the thing the artefact is about: durable across revisions. Two artefacts that share a logical_id are two versions of the same underlying item. Producers SHOULD assign on first creation and reuse on every revision, override or supersession. CHAP itself reads only `id`; logical_id is for higher-layer version-graph projection.",
           "pattern": "^lgl_[0-9A-HJKMNP-TV-Z]{26}$"
         },
         "instance_id": {

--- a/schemas/profiles/chap-methods.schema.json
+++ b/schemas/profiles/chap-methods.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://chap.dev/schemas/0.2/chap-methods.schema.json",
   "title": "CHAP Method Catalogue",
-  "description": "Authoritative catalogue of methods defined by CHAP v0.2 across Core and the profile suite. Every method declares `since` (the layer that introduces it — `core/1.0` or `<profile>/<version>`) and `implementation_status` (`implemented` if present in at least one v0.2 reference implementation under `reference/`, otherwise `spec-only`). Note: the v0.2 reference implementations use simplified `task.create` + `task.update` calls in place of the full `task.assign / accept / decline / start / progress` lifecycle described in SPECIFICATION.md §12.3; the catalogue records both — the spec methods are the canonical surface, the *_create/update variants are reference-only simplifications.",
+  "description": "Authoritative catalogue of methods defined by CHAP v0.2 across Core and the profile suite. Every method declares `since` (the layer that introduces it: `core/1.0` or `<profile>/<version>`) and `implementation_status` (`implemented` if present in at least one v0.2 reference implementation under `reference/`, otherwise `spec-only`). Note: the v0.2 reference implementations use simplified `task.create` + `task.update` calls in place of the full `task.assign / accept / decline / start / progress` lifecycle described in SPECIFICATION.md §12.3; the catalogue records both: the spec methods are the canonical surface, the *_create/update variants are reference-only simplifications.",
   "type": "object",
   "required": ["version", "methods"],
   "properties": {

--- a/tools/audit-viewer.html
+++ b/tools/audit-viewer.html
@@ -168,7 +168,7 @@
 
   <section class="body">
     <div id="empty" class="empty">
-      Drop a CHAP workspace export on the left to inspect its audit chain and override patterns. Nothing leaves your browser — everything renders client-side.
+      Drop a CHAP workspace export on the left to inspect its audit chain and override patterns. Nothing leaves your browser, everything renders client-side.
     </div>
     <div id="chain" class="chain" style="display:none"></div>
   </section>


### PR DESCRIPTION
Version unchanged; this is documentation and CI only.

The 0.2.7 changelog section, 218 lines covering the framework bridges, the scenarios directory and the cross-implementation fixes, was absent from the tree 0.2.9 was built from and was deleted by that commit. Restored verbatim from 9e7af2b. Every other version section is byte-identical, so that was the only loss. A 0.2.8 entry is added: it published the 0.2.7 line and carried nothing of its own, which is why it never had a heading.

The error registry

SPECIFICATION 13.2 allocated overlapping bands, giving -32600 to both the JSON-RPC standard errors and CHAP task errors, and -32700 to both parse errors and evidence errors. 13.3 inherited the collision: -32600, -32601 and -32602 each carried two meanings, mode_ceiling_exceeded had a code no implementation used, and several named errors have never been returned by anything.

13.2 now gives each profile one decade with no overlap, so a code identifies its profile on sight. 13.3 carries the five JSON-RPC codes and defers to each profile's own table as authoritative, rather than mirroring 49 codes that would drift again. The two implementations agree exactly, 49 codes each with no duplicates, so they were the reference for both.

identity-vc/1.0 assigned -32411 to issuer trust and -32413 to claim disclosure while both coordinators use them for holder binding and unknown schema. The table now matches what is returned. Issuer trust and claim disclosure are recorded as described but unimplemented rather than deleted, since they are plausible future conditions.

Process documents

CONTRIBUTING called the proposal process "CHAP Improvement Proposals" once and "RFC-style proposal" three times, while GOVERNANCE defines CEPs. All now say CEP, and CONTRIBUTING points at ceps/ and the governing section.

MAINTAINERS.md is added, which SECURITY, GOVERNANCE and CODE_OF_CONDUCT all referred to. It states the present position: CHAP 0.2 has a single maintainer who takes responsibility for protocol decisions. GOVERNANCE 2 describes Editors implementing consensus, a Steering Committee ratifying, and Working Groups; none of that is constituted, so MAINTAINERS marks it as the intended structure for standards-track promotion and itself as the description of today. GOVERNANCE is left unchanged for now.

Gates

The em-dash check covered *.md only, so they had accumulated in playground UI copy, schema descriptions, package descriptions and the audit viewer. Cleared from all of them, and the check widened to source, schema and UI files.

A guard now rejects bare require() in ES module sources. Three faults this release had that single cause, and the guard immediately found a fourth: the corrupt-row recovery suite had been skipping silently for the same reason as the storage suites, so it is fixed here too.