### PR TITLE
Refresh oidc_acr on participant re-join (Python)

### DIFF
--- a/packages/coordinator-py/chap_coordinator/coordinator.py
+++ b/packages/coordinator-py/chap_coordinator/coordinator.py
@@ -859,7 +859,7 @@ class Coordinator:
 
         existing = ws.members.get(uri)
         if existing is not None:
-            for f in ("oidc_sub", "oidc_auth_time", "vc_holder"):
+            for f in ("oidc_sub", "oidc_auth_time", "oidc_acr", "vc_holder"):
                 v = getattr(member, f)
                 if v is not None:
                     setattr(existing, f, v)

--- a/packages/coordinator-py/tests/test_step_up.py
+++ b/packages/coordinator-py/tests/test_step_up.py
@@ -59,3 +59,26 @@ def test_step_up_enforces_min_acr():
 
     ok = _privileged(c, "human:bob")
     assert "error" not in ok or ok["error"]["code"] != -32402
+
+
+def test_min_acr_not_bypassed_by_downgraded_rejoin():
+    fresh = int(time.time())
+
+    def verify(token):
+        return {"sub": "u", "auth_time": fresh,
+                "acr": "mfa" if token == "strong" else "pwd"}
+
+    c = Coordinator(CoordinatorOptions(enforce_step_up=True, verify_oidc_token=verify))
+    c.dispatch({"jsonrpc": "2.0", "id": "1", "method": "workspace.create",
+                "params": {"workspace": "w", "min_acr": "mfa"}})
+    c.dispatch({"jsonrpc": "2.0", "id": "2", "method": "participant.join",
+                "params": {"workspace": "w", "from": "human:alice", "type": "human",
+                           "role": "admin", "oidc_token": "strong"}})
+    assert _privileged(c, "human:alice").get("error", {}).get("code") != -32402
+
+    # Re-join with a downgraded token: fresh auth_time but a weaker acr. The
+    # stale strong acr must not be retained.
+    c.dispatch({"jsonrpc": "2.0", "id": "3", "method": "participant.join",
+                "params": {"workspace": "w", "from": "human:alice", "type": "human",
+                           "oidc_token": "weak"}})
+    assert _privileged(c, "human:alice")["error"]["code"] == -32402

--- a/packages/coordinator/tests/step_up.test.ts
+++ b/packages/coordinator/tests/step_up.test.ts
@@ -42,3 +42,19 @@ test("step-up enforces min_acr", () => {
   assert.equal(privileged(c, "human:alice").error?.code, -32402);
   assert.notEqual(privileged(c, "human:bob").error?.code, -32402);
 });
+
+test("min_acr is not bypassed by a downgraded re-join", () => {
+  const fresh = Math.floor(Date.now() / 1000);
+  const c = new Coordinator({ enforceStepUp: true,
+    verifyOidcToken: (t: string) => ({ sub: "u", auth_time: fresh, acr: t === "strong" ? "mfa" : "pwd" }) });
+  c.dispatch({ jsonrpc: "2.0", id: "1", method: "workspace.create",
+    params: { workspace: "w", min_acr: "mfa" }});
+  c.dispatch({ jsonrpc: "2.0", id: "2", method: "participant.join",
+    params: { workspace: "w", from: "human:alice", type: "human", role: "admin", oidc_token: "strong" }});
+  assert.notEqual(privileged(c, "human:alice").error?.code, -32402);
+
+  // Re-join with a downgraded token: fresh auth_time but a weaker acr.
+  c.dispatch({ jsonrpc: "2.0", id: "3", method: "participant.join",
+    params: { workspace: "w", from: "human:alice", type: "human", oidc_token: "weak" }});
+  assert.equal(privileged(c, "human:alice").error?.code, -32402);
+});


### PR DESCRIPTION
Fixes an `acr`-downgrade gap surfaced by a fresh audit — a Python/TypeScript divergence I
introduced in #45.

The Python participant re-join update loop refreshed `oidc_sub` / `oidc_auth_time` /
`vc_holder` on an existing member but **not `oidc_acr`** (TS already refreshed it). Under
`enforce_step_up` with a workspace `min_acr`, a member who first joined with a strong token
(`acr = mfa`) could re-join with a **fresh `auth_time` but a downgraded `acr` (`pwd`)**:
Python refreshed the timestamp (so the freshness check passed) but kept the stale strong
`acr`, so `_check_step_up`'s `min_acr` gate passed at an authentication strength the actor
no longer held. Privileged methods then ran.

`oidc_acr` is now included in the re-join refresh loop, matching TS.

Regression test in both references: after a downgraded re-join the privileged method is
denied `-32402`; the test fails on pre-fix Python and passes on TS (confirming parity).
Python 242/242, TS 184/184, typecheck clean.
