### PR TITLE
Gate review exit behind decide.* in task.update

### DIFF
--- a/packages/coordinator-py/chap_coordinator/coordinator.py
+++ b/packages/coordinator-py/chap_coordinator/coordinator.py
@@ -952,7 +952,7 @@ class Coordinator:
             "created":          ["in_progress", "declined", "paused"],
             "in_progress":      ["in_progress", "completed", "declined",
                                  "review_requested", "paused"],
-            "review_requested": ["in_progress", "completed", "declined"],
+            "review_requested": ["in_progress"],
             "paused":           ["in_progress", "cancelled"],
         }
         if new_state not in legal.get(task.state, []):

--- a/packages/coordinator-py/tests/test_review.py
+++ b/packages/coordinator-py/tests/test_review.py
@@ -103,3 +103,22 @@ def test_escalate_raise(coord_with_task):
                        "assignee": "human:senior@x"})
     assert "result" in r
     assert r["result"]["escalated_from"] == tid
+
+
+def test_task_update_cannot_complete_task_awaiting_review(coord_with_task):
+    coord, send, tid = coord_with_task
+    send("review.request", workspace="wsp_r", task_id=tid,
+         **{"from": "agent:bot", "to": "human:alice@x", "artefact": {"text": "draft"}})
+
+    # The drafter tries to self-complete the task under review, with no reviewer
+    # decision. The review gate lives in decide.*/abstain (reviewer-gated); a plain
+    # task.update by a member must not reach a terminal state around it.
+    bypass = send("task.update", workspace="wsp_r", task_id=tid,
+                  **{"from": "agent:bot", "state": "completed"})
+    assert "error" in bypass
+    assert coord.get_workspace("wsp_r").tasks[tid].state == "review_requested"
+
+    # Withdrawing the review request back to in_progress stays legal.
+    withdraw = send("task.update", workspace="wsp_r", task_id=tid,
+                    **{"from": "agent:bot", "state": "in_progress"})
+    assert withdraw["result"]["state"] == "in_progress"

--- a/packages/coordinator/src/coordinator.ts
+++ b/packages/coordinator/src/coordinator.ts
@@ -927,7 +927,7 @@ export class Coordinator {
     const legal: Record<string, string[]> = {
       created:          ["in_progress", "declined", "paused"],
       in_progress:      ["in_progress", "completed", "declined", "review_requested", "paused"],
-      review_requested: ["in_progress", "completed", "declined"],
+      review_requested: ["in_progress"],
       paused:           ["in_progress", "cancelled"],
     };
     if (!legal[task.state]?.includes(newState)) {

--- a/packages/coordinator/tests/review.test.ts
+++ b/packages/coordinator/tests/review.test.ts
@@ -89,3 +89,22 @@ test("escalate.raise creates a new task that supersedes the original", () => {
   assert.ok("result" in r && !r.error);
   assert.equal((r.result as { escalated_from: string }).escalated_from, tid);
 });
+
+test("task.update cannot complete a task awaiting review", () => {
+  const { c, send, tid } = setup();
+  send("review.request", { workspace: "wsp_r", from: "agent:bot",
+    to: "human:alice", task_id: tid, artefact: { text: "draft" } });
+
+  // The drafter tries to self-complete the task under review, with no reviewer
+  // decision. The review gate lives in decide.*/abstain (reviewer-gated); a plain
+  // task.update by a member must not reach a terminal state around it.
+  const bypass = send("task.update", { workspace: "wsp_r", from: "agent:bot",
+    task_id: tid, state: "completed" });
+  assert.ok(bypass.error, "task.update must not complete a task awaiting review");
+  assert.equal(c.workspaces.get("wsp_r")!.tasks.get(tid)!.state, "review_requested");
+
+  // Withdrawing the review request back to in_progress stays legal.
+  const withdraw = send("task.update", { workspace: "wsp_r", from: "agent:bot",
+    task_id: tid, state: "in_progress" });
+  assert.equal((withdraw.result as { state: string }).state, "in_progress");
+});


### PR DESCRIPTION
Closes #87.

`task.update` accepted `review_requested -> completed` and `review_requested -> declined`, both membership-gated only, so the assignee could move a task out of review to a terminal state with no reviewer decision and without setting `task.output` — bypassing the review gate.

Per `SPECIFICATION.md` §8.1 the only exits from `review_requested` are `decide.approve`/`decide.override` (→ completed), `decide.reject` (→ in_progress/declined) and `review.request`; §8.3 gates completion on the `review.rule` predicate. `task.update` is not among them.

This restricts `task.update`'s `review_requested` transitions to `["in_progress"]` — a non-terminal withdrawal that de-escalates rather than bypasses, and the sole escape for a task that entered `review_requested` without the review profile. Matches `reference/core-plus-review/server.ts`, which already does this.

**Both refs** changed identically. Regression tests added to `review.test.ts` and `test_review.py` (drafter's `task.update state=completed` under review must error and leave the task `review_requested`; withdrawal to `in_progress` still works). Verified the tests fail on pre-fix code. Full suites green (Python 242, TS 185), typecheck clean.