### PR TITLE
Reject rotated-out keys for live requests by the trusted clock

### DIFF
--- a/packages/coordinator-py/chap_coordinator/coordinator.py
+++ b/packages/coordinator-py/chap_coordinator/coordinator.py
@@ -596,6 +596,13 @@ class Coordinator:
         for k in member.keys:
             if k.kid == kid and k.revoked_at is not None and now >= k.revoked_at:
                 return rpc_error(E.SIG_KEY_REVOKED, f"Key {kid} is revoked")
+            # Expiry is present-tense for the same reason: a rotated-out key
+            # (valid_until set to the rotation time, but never explicitly
+            # revoked) must not sign live requests. Selecting it by the
+            # self-asserted `ts` alone lets its holder backdate `ts` to before
+            # valid_until and keep using it. Judge expiry by the trusted clock.
+            if k.kid == kid and k.valid_until is not None and now >= k.valid_until:
+                return rpc_error(E.SIG_KEY_NOT_FOUND, f"Key {kid} is no longer valid")
         key = member.key_for(kid, ts)
         if not key:
             for k in member.keys:

--- a/packages/coordinator-py/tests/test_identity_and_signed.py
+++ b/packages/coordinator-py/tests/test_identity_and_signed.py
@@ -374,3 +374,43 @@ def test_vc_presentation_invalid_rejected():
                    "vc_presentation": {"type": "Bogus"}},
     })
     assert r["error"]["code"] == -32410  # VC_VP_INVALID
+
+
+def test_rotated_out_key_cannot_sign_live_via_backdated_ts():
+    c = Coordinator(CoordinatorOptions(require_signatures=True,
+                                       deterministic_ids=True, deterministic_clock=True))
+    c.dispatch({"jsonrpc": "2.0", "id": "1", "method": "workspace.create",
+                "params": {"workspace": "w"}})
+    sk1, pub1 = _gen_keypair()
+    sk2, pub2 = _gen_keypair()
+    _, pub_bot = _gen_keypair()
+    jwk1 = {"kty": "OKP", "crv": "Ed25519", "kid": "k1", "x": _b64url_nopad(pub1)}
+    jwk2 = {"kty": "OKP", "crv": "Ed25519", "kid": "k2", "x": _b64url_nopad(pub2)}
+    jwk_bot = {"kty": "OKP", "crv": "Ed25519", "kid": "kb", "x": _b64url_nopad(pub_bot)}
+    c.dispatch({"jsonrpc": "2.0", "id": "2", "method": "participant.join",
+                "params": {"workspace": "w", "from": "human:alice", "type": "human",
+                           "role": "owner", "jwks": {"keys": [jwk1]},
+                           "profiles": ["core/1.0", "security-signed/1.0"]}})
+    c.dispatch({"jsonrpc": "2.0", "id": "2b", "method": "participant.join",
+                "params": {"workspace": "w", "from": "agent:bot", "type": "agent",
+                           "role": "drafter", "jwks": {"keys": [jwk_bot]}}})
+
+    # Rotate alice's key (signed with the old key); this sets valid_until on k1.
+    rot = {"jsonrpc": "2.0", "id": "3", "method": "participant.rotate_key",
+           "params": {"workspace": "w", "from": "human:alice",
+                      "old_kid": "k1", "new_jwk": jwk2}}
+    _sign_envelope(sk1, rot, "k1")
+    assert c.dispatch(rot)["result"]["rotated"] is True
+
+    k1 = next(k for k in c.workspaces["w"].members["human:alice"].keys if k.kid == "k1")
+    assert k1.valid_until is not None
+
+    # The holder of the rotated-out key backdates ts into the old key's validity
+    # window (valid_from is always inside it) and signs a live request. It must
+    # be rejected: the old key is no longer valid per the trusted clock,
+    # regardless of the self-asserted ts.
+    env = {"jsonrpc": "2.0", "id": "4", "method": "task.create",
+           "params": {"workspace": "w", "from": "human:alice", "kind": "draft",
+                      "input": {}, "assignee": "agent:bot", "ts": k1.valid_from}}
+    _sign_envelope(sk1, env, "k1")
+    assert c.dispatch(env)["error"]["code"] == -32071  # SIG_KEY_NOT_FOUND

--- a/packages/coordinator/src/coordinator.ts
+++ b/packages/coordinator/src/coordinator.ts
@@ -593,6 +593,14 @@ export class Coordinator {
     if (member.keys.some(k => k.kid === kid && k.revoked_at !== undefined && now >= k.revoked_at)) {
       return rpcError(E.SIG_KEY_REVOKED, `Key ${kid} is revoked`);
     }
+    // Expiry is present-tense for the same reason: a rotated-out key
+    // (valid_until set to the rotation time, but never explicitly revoked) must
+    // not sign live requests. Selecting it by the self-asserted `ts` alone lets
+    // its holder backdate `ts` to before valid_until and keep using it. Judge
+    // expiry by the trusted clock.
+    if (member.keys.some(k => k.kid === kid && k.valid_until !== undefined && now >= k.valid_until)) {
+      return rpcError(E.SIG_KEY_NOT_FOUND, `Key ${kid} is no longer valid`);
+    }
 
     const key = this.lookupKey(member, kid, ts);
     if (!key) {

--- a/packages/coordinator/tests/identity_and_signed.test.ts
+++ b/packages/coordinator/tests/identity_and_signed.test.ts
@@ -238,3 +238,39 @@ test("VC invalid presentation returns -32410", () => {
               vc_presentation: { type: "Bogus" }}});
   assert.equal(r.error?.code, -32410);
 });
+
+test("a rotated-out key cannot sign live requests via a backdated ts", () => {
+  const c = new Coordinator({ requireSignatures: true,
+    deterministicIds: true, deterministicClock: true });
+  const k1 = genKeypair();
+  const k2 = genKeypair();
+  const bot = genKeypair();
+  c.dispatch({ jsonrpc: "2.0", id: "1", method: "workspace.create",
+    params: { workspace: "w" }});
+  c.dispatch({ jsonrpc: "2.0", id: "2", method: "participant.join",
+    params: { workspace: "w", from: "human:alice", type: "human", role: "owner",
+              jwks: { keys: [k1.jwk] }, profiles: ["core/1.0", "security-signed/1.0"] }});
+  c.dispatch({ jsonrpc: "2.0", id: "2b", method: "participant.join",
+    params: { workspace: "w", from: "agent:bot", type: "agent", role: "drafter",
+              jwks: { keys: [bot.jwk] }}});
+
+  // Rotate alice's key (signed with the old key); this sets valid_until on k1.
+  const rot: Envelope = { jsonrpc: "2.0", id: "3", method: "participant.rotate_key",
+    params: { workspace: "w", from: "human:alice", old_kid: k1.jwk.kid, new_jwk: k2.jwk }};
+  signed(rot, k1.sk, k1.jwk.kid);
+  assert.ok((c.dispatch(rot).result as { rotated: boolean }).rotated);
+
+  const k1rec = c.workspaces.get("w")!.members.get("human:alice")!
+    .keys.find(k => k.kid === k1.jwk.kid)!;
+  assert.ok(k1rec.valid_until !== undefined);
+
+  // The holder of the rotated-out key backdates ts into the old key's validity
+  // window (valid_from is always inside it) and signs a live request. It must
+  // be rejected: the old key is no longer valid per the trusted clock,
+  // regardless of the self-asserted ts.
+  const env: Envelope = { jsonrpc: "2.0", id: "4", method: "task.create",
+    params: { workspace: "w", from: "human:alice", kind: "draft", input: {},
+              assignee: "agent:bot", ts: k1rec.valid_from }};
+  signed(env, k1.sk, k1.jwk.kid);
+  assert.equal(c.dispatch(env).error?.code, -32071);  // SIG_KEY_NOT_FOUND
+});


### PR DESCRIPTION
Closes #89.

Signature verification judged revocation by the trusted clock but still judged key expiry (`valid_until`) by the envelope's self-asserted `ts`. `participant.rotate_key` sets the old key's `valid_until` to the rotation time and leaves `revoked_at` unset, so a holder of a rotated-out key could backdate `ts` into `[valid_from, valid_until)` and keep signing live requests — the same backdating class the revocation check already closed.

This applies the present-tense rule to expiry: a key whose `valid_until` has passed per the trusted clock is rejected regardless of the self-asserted `ts`. Only live dispatch is affected; `ts`-based lookup for historical audit-chain verification (`SPECIFICATION.md` §5.2) does not run through live `_verify_signature` and is unchanged.

**Both refs** were affected and are fixed identically (the branch name mentions Python but the TS fix is included). Regression tests added to `identity_and_signed.test.ts` and `test_identity_and_signed.py`: rotate a key, then sign a live request with the old key at `ts = valid_from` — must be rejected with `SIG_KEY_NOT_FOUND`. Verified both fail on pre-fix code. Full suites green (Python 242, TS 184), typecheck clean.