### PR TITLE
Apply the mode ceiling and trial review to control.supersede

### DIFF
--- a/packages/coordinator-py/chap_coordinator/profiles/control.py
+++ b/packages/coordinator-py/chap_coordinator/profiles/control.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from ..coordinator import mode_le
 from ..jsonrpc import E, rpc_error
 from ..types import SnapshotArtefact, Task, TaskHistoryEntry
 
@@ -234,6 +235,16 @@ def register_control(coord: "Coordinator") -> None:
             return {"error": rpc_error(E.PARAMS,
                                        "successor assignee not in workspace")}
 
+        # The successor is a created task, so it is bound by the same modes/1.0
+        # invariants as task.create: it must not exceed the workspace ceiling,
+        # and a trial-mode task forces review on regardless of its own setting.
+        requested_mode = new_spec.get("mode") or old.mode
+        if not mode_le(requested_mode, ws.mode_ceiling):
+            return {"error": rpc_error(
+                E.MODE_CEILING_EXCEEDED,
+                f"Requested mode {requested_mode} exceeds ceiling {ws.mode_ceiling}",
+            )}
+
         now = coord.now_iso()
         new_id = coord.ids.task_id()
         new_task = Task(
@@ -245,13 +256,17 @@ def register_control(coord: "Coordinator") -> None:
             input=new_spec.get("input") or {},
             created_at=now,
             updated_at=now,
-            mode=new_spec.get("mode") or old.mode,
+            mode=requested_mode,
             supersedes=old.id,
             history=[TaskHistoryEntry(
                 ts=now, from_=p.get("from", ""), state="created",
                 note=f"supersedes {old.id}: {p.get('reason') or ''}",
             )],
         )
+        if new_task.mode == "trial":
+            new_task.review_required = True
+        elif "review_required" in new_spec:
+            new_task.review_required = bool(new_spec["review_required"])
         ws.tasks[new_id] = new_task
 
         old.state = "superseded"

--- a/packages/coordinator-py/tests/test_profiles.py
+++ b/packages/coordinator-py/tests/test_profiles.py
@@ -425,3 +425,52 @@ def test_audit_submit_to_scitt_with_submitter(ready):
              **{"from": "service:coordinator"})
     assert "receipts" in r["result"]
     assert len(r["result"]["receipts"]) > 0
+
+
+def test_supersede_cannot_exceed_mode_ceiling():
+    coord = Coordinator(CoordinatorOptions(deterministic_ids=True, deterministic_clock=True))
+
+    def send(method, **params):
+        return coord.dispatch({"jsonrpc": "2.0", "id": f"t-{method}",
+                               "method": method, "params": params})
+
+    send("workspace.create", workspace="w", mode_ceiling="trial")
+    send("participant.join", workspace="w",
+         **{"from": "human:alice", "type": "human", "role": "owner"})
+    send("participant.join", workspace="w",
+         **{"from": "agent:bot", "type": "agent", "role": "drafter"})
+    tid = send("task.create", workspace="w",
+               **{"from": "human:alice", "kind": "draft", "input": {},
+                  "assignee": "agent:bot", "mode": "trial"})["result"]["task_id"]
+
+    # The successor is a created task, so the ceiling binds it too.
+    r = send("control.supersede", workspace="w", **{"from": "human:alice"},
+             task_id=tid, successor_task={"kind": "draft", "assignee": "agent:bot",
+                                          "mode": "production"})
+    assert r.get("error", {}).get("code") == -32040  # MODE_CEILING_EXCEEDED
+    # Rejected before any mutation: the old task is untouched.
+    assert coord.workspaces["w"].tasks[tid].state != "superseded"
+
+
+def test_supersede_trial_forces_review():
+    coord = Coordinator(CoordinatorOptions(deterministic_ids=True, deterministic_clock=True))
+
+    def send(method, **params):
+        return coord.dispatch({"jsonrpc": "2.0", "id": f"t-{method}",
+                               "method": method, "params": params})
+
+    send("workspace.create", workspace="w", mode_ceiling="production")
+    send("participant.join", workspace="w",
+         **{"from": "human:alice", "type": "human", "role": "owner"})
+    send("participant.join", workspace="w",
+         **{"from": "agent:bot", "type": "agent", "role": "drafter"})
+    tid = send("task.create", workspace="w",
+               **{"from": "human:alice", "kind": "draft", "input": {},
+                  "assignee": "agent:bot", "mode": "production"})["result"]["task_id"]
+
+    # A trial-mode successor forces review on regardless of its own setting.
+    r = send("control.supersede", workspace="w", **{"from": "human:alice"},
+             task_id=tid, successor_task={"kind": "draft", "assignee": "agent:bot",
+                                          "mode": "trial", "review_required": False})
+    new_id = r["result"]["new_task_id"]
+    assert coord.workspaces["w"].tasks[new_id].review_required is True

--- a/packages/coordinator/src/profiles/control.ts
+++ b/packages/coordinator/src/profiles/control.ts
@@ -11,6 +11,7 @@
  */
 import type { Coordinator } from "../coordinator.js";
 import { E, rpcError } from "../jsonrpc.js";
+import { modeLE } from "../types.js";
 import type { Mode, SnapshotArtefact, Task } from "../types.js";
 
 const VALID_MODES = new Set<Mode>(["shadow", "trial", "production"]);
@@ -178,6 +179,14 @@ export function registerControl(coord: Coordinator): void {
     if (!ws.members.has(assignee)) {
       return { error: rpcError(E.PARAMS, "successor assignee not in workspace") };
     }
+    // The successor is a created task, so it is bound by the same modes/1.0
+    // invariants as task.create: it must not exceed the workspace ceiling, and
+    // a trial-mode task forces review on regardless of its own setting.
+    const requestedMode = (newSpec.mode as Mode) ?? old.mode;
+    if (!modeLE(requestedMode, ws.mode_ceiling)) {
+      return { error: rpcError(E.MODE_CEILING_EXCEEDED,
+        `Requested mode ${requestedMode} exceeds ceiling ${ws.mode_ceiling}`) };
+    }
     const now = coord.now();
     const newId = coord.ids.taskId();
     const newTask: Task = {
@@ -189,12 +198,14 @@ export function registerControl(coord: Coordinator): void {
       input: (newSpec.input as Record<string, unknown>) ?? {},
       created_at: now,
       updated_at: now,
-      mode: (newSpec.mode as Mode) ?? old.mode,
+      mode: requestedMode,
       supersedes: old.id,
       history: [{ ts: now, from: p.from as string, state: "created",
                   note: `supersedes ${old.id}: ${(p.reason as string) || ""}` }],
       paused: false,
     };
+    if (newTask.mode === "trial") newTask.review_required = true;
+    else if ("review_required" in newSpec) newTask.review_required = !!newSpec.review_required;
     ws.tasks.set(newId, newTask);
     old.state = "superseded";
     old.superseded_by = newId;

--- a/packages/coordinator/tests/profiles.test.ts
+++ b/packages/coordinator/tests/profiles.test.ts
@@ -369,3 +369,36 @@ test("audit.submit_to_scitt with submitter calls the hook", () => {
   const r = send("audit.submit_to_scitt", { workspace: "wsp_p2", from: "service:coordinator" });
   assert.ok((r.result as { receipts: unknown[] }).receipts.length > 0);
 });
+
+test("control.supersede cannot exceed the mode ceiling", () => {
+  const c = new Coordinator({ deterministicIds: true, deterministicClock: true });
+  const send = (m: string, p: Record<string, unknown>) =>
+    c.dispatch({ jsonrpc: "2.0", id: `t-${m}`, method: m, params: p });
+  send("workspace.create", { workspace: "w", mode_ceiling: "trial" });
+  send("participant.join", { workspace: "w", from: "human:alice", type: "human", role: "owner" });
+  send("participant.join", { workspace: "w", from: "agent:bot", type: "agent", role: "drafter" });
+  const tid = (send("task.create", { workspace: "w", from: "human:alice", kind: "draft",
+    input: {}, assignee: "agent:bot", mode: "trial" }).result as { task_id: string }).task_id;
+
+  // The successor is a created task, so the ceiling binds it too.
+  const r = send("control.supersede", { workspace: "w", from: "human:alice", task_id: tid,
+    successor_task: { kind: "draft", assignee: "agent:bot", mode: "production" }});
+  assert.equal(r.error?.code, -32040);  // MODE_CEILING_EXCEEDED
+  assert.notEqual(c.workspaces.get("w")!.tasks.get(tid)!.state, "superseded");
+});
+
+test("control.supersede forces review on a trial successor", () => {
+  const c = new Coordinator({ deterministicIds: true, deterministicClock: true });
+  const send = (m: string, p: Record<string, unknown>) =>
+    c.dispatch({ jsonrpc: "2.0", id: `t-${m}`, method: m, params: p });
+  send("workspace.create", { workspace: "w", mode_ceiling: "production" });
+  send("participant.join", { workspace: "w", from: "human:alice", type: "human", role: "owner" });
+  send("participant.join", { workspace: "w", from: "agent:bot", type: "agent", role: "drafter" });
+  const tid = (send("task.create", { workspace: "w", from: "human:alice", kind: "draft",
+    input: {}, assignee: "agent:bot", mode: "production" }).result as { task_id: string }).task_id;
+
+  const r = send("control.supersede", { workspace: "w", from: "human:alice", task_id: tid,
+    successor_task: { kind: "draft", assignee: "agent:bot", mode: "trial", review_required: false }});
+  const newId = (r.result as { new_task_id: string }).new_task_id;
+  assert.equal(c.workspaces.get("w")!.tasks.get(newId)!.review_required, true);
+});


### PR DESCRIPTION
Closes #91.

`control.supersede` creates a successor task but skipped the two modes/1.0 invariants `task.create` enforces: it took the caller's successor mode with no ceiling check, and never forced review on a trial successor. A member could supersede a task into a mode above the workspace ceiling, or into trial with review off.

The ceiling is a workspace-wide invariant (`modes.md`: the highest mode any task may run at; MUST reject over-ceiling `task.create` with `-32040`) and trial forces review regardless of a task's own `review_required` (`modes.md` §3.2/§6). A successor is a created task, so both bind it. This runs the same `mode_le(ceiling)` check before creating the successor and forces `review_required` on a trial successor, exactly as `task.create` does. `control.supersede` remains allowed from any task state (§8.1) — unchanged.

**Both refs** fixed identically. Regression tests added to `test_profiles.py` and `profiles.test.ts` (supersede into a mode above the ceiling → `-32040`, old task untouched; trial successor with `review_required: false` → forced true). Verified both fail on pre-fix code. Full suites green (Python 243, TS 185), typecheck clean.