### PR TITLE
Reject prototype-polluting path segments in the reference patch

### DIFF
--- a/reference/core-plus-review/package.json
+++ b/reference/core-plus-review/package.json
@@ -10,6 +10,7 @@
     "start:demo":   "tsx server.ts",
     "demo:client":  "tsx client.ts",
     "analyze":      "tsx analyze-overrides.ts",
+    "test":         "tsx --test *.test.ts",
     "demo": "tsx server.ts & sleep 1 && tsx client.ts && tsx analyze-overrides.ts && kill %1"
   },
   "devDependencies": {

--- a/reference/core-plus-review/patch.test.ts
+++ b/reference/core-plus-review/patch.test.ts
@@ -1,0 +1,26 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { applyJsonPatch } from "./server.ts";
+
+test("applyJsonPatch refuses __proto__ segments (prototype pollution)", () => {
+  assert.throws(() => applyJsonPatch({ a: 1 }, [
+    { op: "add", path: "/__proto__/polluted", value: "yes" } as never,
+  ]));
+  // Object.prototype must be untouched.
+  assert.equal(({} as Record<string, unknown>).polluted, undefined);
+});
+
+test("applyJsonPatch refuses constructor/prototype segments", () => {
+  assert.throws(() => applyJsonPatch({ a: 1 }, [
+    { op: "replace", path: "/constructor/prototype/x", value: 1 } as never,
+  ]));
+  assert.equal(({} as Record<string, unknown>).x, undefined);
+});
+
+test("applyJsonPatch still applies a normal patch", () => {
+  const out = applyJsonPatch({ severity: "warning" }, [
+    { op: "replace", path: "/severity", value: "info" } as never,
+  ]);
+  assert.deepEqual(out, { severity: "info" });
+});

--- a/reference/core-plus-review/server.ts
+++ b/reference/core-plus-review/server.ts
@@ -14,6 +14,7 @@
  */
 
 import { createServer, IncomingMessage, ServerResponse } from "node:http";
+import { pathToFileURL } from "node:url";
 import { createHash } from "node:crypto";
 
 // ============================================================
@@ -195,7 +196,10 @@ function err(code: number, message: string, data?: unknown) {
 //   Minimal RFC 6902 JSON Patch - apply
 // ============================================================
 
-function applyJsonPatch(doc: unknown, ops: JsonPatchOp[]): unknown {
+// Rejected in every JSON Pointer segment: these enable prototype pollution.
+const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+export function applyJsonPatch(doc: unknown, ops: JsonPatchOp[]): unknown {
   // Deep-clone the document to avoid mutating the original.
   const target = JSON.parse(JSON.stringify(doc));
 
@@ -206,11 +210,18 @@ function applyJsonPatch(doc: unknown, ops: JsonPatchOp[]): unknown {
     if (parts.length === 0) {
       throw new Error(`Cannot operate on root path`);
     }
+    for (const seg of parts) {
+      if (DANGEROUS_KEYS.has(seg)) {
+        throw new Error(`Refusing unsafe path segment ${JSON.stringify(seg)}`);
+      }
+    }
 
     let parent: any = target;
     for (let i = 0; i < parts.length - 1; i++) {
       const key = Array.isArray(parent) ? parseInt(parts[i], 10) : parts[i];
-      if (parent[key] === undefined) {
+      // hasOwnProperty, not `=== undefined`: an inherited property (e.g. via a
+      // crafted path) must not be treated as a traversable node.
+      if (!Object.prototype.hasOwnProperty.call(parent, key)) {
         throw new Error(`Path not found: ${op.path}`);
       }
       parent = parent[key];
@@ -755,8 +766,12 @@ const server = createServer(async (req, res) => {
   reply(res, response.error ? 400 : 200, response);
 });
 
-const port = parseInt(process.env.PORT ?? "8080", 10);
-server.listen(port, () => {
-  console.log(`CHAP Core+Review reference on http://localhost:${port}/chap`);
-  console.log(`Profiles: core/1.0, review/1.0`);
-});
+// Only start listening when run directly (tsx server.ts), not when the module
+// is imported -- e.g. by the patch test, which exercises applyJsonPatch alone.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const port = parseInt(process.env.PORT ?? "8080", 10);
+  server.listen(port, () => {
+    console.log(`CHAP Core+Review reference on http://localhost:${port}/chap`);
+    console.log(`Profiles: core/1.0, review/1.0`);
+  });
+}


### PR DESCRIPTION
Closes #94.

The `core-plus-review` reference server's `applyJsonPatch` walked the JSON Pointer with no guard on segment names and assigned through `parent[lastKey]`, so a `decide.override` diff with `/__proto__/polluted` or `/constructor/prototype/x` wrote onto `Object.prototype` and polluted every object in the process.

Rejects `__proto__`/`constructor`/`prototype` in every segment and traverses with `hasOwnProperty` rather than `=== undefined` (which an inherited property satisfies) — mirroring the shipped `packages/coordinator/src/patch.ts`, which already does this.

The reference had no tests, so this also exports `applyJsonPatch`, guards `listen()` behind a run-directly check (importing the module no longer starts the server), and adds `patch.test.ts` + a `test` script. The two pollution tests fail on pre-fix and pass after; the server still boots and serves when run directly. Scoped to the reference server; the shipped coordinators were already safe.