### PR TITLE
Gate modes/1.0 behaviour on the profile and enforce review_required

### DIFF
--- a/packages/coordinator-py/chap_coordinator/coordinator.py
+++ b/packages/coordinator-py/chap_coordinator/coordinator.py
@@ -938,8 +938,10 @@ class Coordinator:
             history=[TaskHistoryEntry(ts=now, from_=p["from"], state="created")],
         )
 
-        # modes/1.0: trial mode forces review.required
-        if task.mode == "trial":
+        # modes/1.0: trial mode forces review.required -- but only when the
+        # workspace has opted into modes/1.0. mode is inert without the profile,
+        # so a plain core/review workspace does not inherit forced review.
+        if ws.has_profile("modes") and task.mode == "trial":
             task.review_required = True
         elif "review_required" in p:
             task.review_required = bool(p["review_required"])
@@ -1001,6 +1003,38 @@ class Coordinator:
         if task.state not in ("created", "in_progress"):
             return {"error": rpc_error(
                 E.PARAMS, f"Cannot complete task in state: {task.state}")}
+        # review/1.0 S3.1: task.complete on a task whose review is required
+        # opens a review implicitly rather than completing. The submitted output
+        # becomes the artefact under review; only a reviewer decision (decide.*)
+        # then takes the task to completed. Without this a review_required task
+        # would reach completed with unreviewed output and no decision.
+        if task.review_required:
+            now = self.now_iso()
+            task.pending_artefact = p.get("output")
+            if task.review is None:
+                # The producer must not satisfy its own review, so the implicit
+                # review is addressed to the other members, excluding the caller
+                # and the assignee. With nobody eligible there is no independent
+                # reviewer, so refuse rather than open a review only its author
+                # could approve. (An explicit review.request keeps its own `to`.)
+                producer = p.get("from", "")
+                eligible = [uri for uri in ws.members
+                            if uri != producer and uri != task.assignee]
+                if not eligible:
+                    return {"error": rpc_error(
+                        E.NOT_AUTHORISED,
+                        "Task requires review but has no eligible reviewer "
+                        "(needs a member other than its assignee and completer)")}
+                task.review = ReviewState(requested_at=now,
+                                          requested_to=list(eligible))
+            task.state = "review_requested"
+            task.updated_at = now
+            task.history.append(TaskHistoryEntry(
+                ts=now, from_=p.get("from", ""), state="review_requested",
+                note="review required; opened on task.complete",
+            ))
+            return {"result": {"state": "review_requested",
+                               "review_id": task.id}}
         task.output = p.get("output")
         if "confidence" in p:
             # Stored as received (number or string) so it hashes deterministically;

--- a/packages/coordinator-py/chap_coordinator/profiles/control.py
+++ b/packages/coordinator-py/chap_coordinator/profiles/control.py
@@ -263,7 +263,9 @@ def register_control(coord: "Coordinator") -> None:
                 note=f"supersedes {old.id}: {p.get('reason') or ''}",
             )],
         )
-        if new_task.mode == "trial":
+        # Trial forces review only when the workspace opted into modes/1.0,
+        # matching task.create -- mode is inert without the profile.
+        if ws.has_profile("modes") and new_task.mode == "trial":
             new_task.review_required = True
         elif "review_required" in new_spec:
             new_task.review_required = bool(new_spec["review_required"])

--- a/packages/coordinator-py/tests/test_profiles.py
+++ b/packages/coordinator-py/tests/test_profiles.py
@@ -459,7 +459,8 @@ def test_supersede_trial_forces_review():
         return coord.dispatch({"jsonrpc": "2.0", "id": f"t-{method}",
                                "method": method, "params": params})
 
-    send("workspace.create", workspace="w", mode_ceiling="production")
+    send("workspace.create", workspace="w", mode_ceiling="production",
+         profiles=["core/1.0", "review/1.0", "modes/1.0"])
     send("participant.join", workspace="w",
          **{"from": "human:alice", "type": "human", "role": "owner"})
     send("participant.join", workspace="w",

--- a/packages/coordinator-py/tests/test_review.py
+++ b/packages/coordinator-py/tests/test_review.py
@@ -122,3 +122,89 @@ def test_task_update_cannot_complete_task_awaiting_review(coord_with_task):
     withdraw = send("task.update", workspace="wsp_r", task_id=tid,
                     **{"from": "agent:bot", "state": "in_progress"})
     assert withdraw["result"]["state"] == "in_progress"
+
+
+def test_task_complete_opens_review_addressed_to_eligible_reviewer():
+    coord = Coordinator(CoordinatorOptions(deterministic_ids=True, deterministic_clock=True))
+
+    def send(method, **params):
+        return coord.dispatch({"jsonrpc": "2.0", "id": f"t-{method}",
+                               "method": method, "params": params})
+
+    send("workspace.create", workspace="w",
+         profiles=["core/1.0", "review/1.0", "modes/1.0"])
+    send("participant.join", workspace="w",
+         **{"from": "human:alice", "type": "human", "role": "reviewer"})
+    send("participant.join", workspace="w",
+         **{"from": "agent:bot", "type": "agent", "role": "drafter"})
+    tid = send("task.create", workspace="w",
+               **{"from": "human:alice", "kind": "draft", "input": {},
+                  "assignee": "agent:bot", "mode": "trial"})["result"]["task_id"]
+    assert coord.workspaces["w"].tasks[tid].review_required is True
+    send("task.update", workspace="w", **{"from": "agent:bot"},
+         task_id=tid, state="in_progress")
+
+    # task.complete opens a review addressed to the eligible reviewer (excluding
+    # the producer/assignee); it does not complete.
+    r = send("task.complete", workspace="w", **{"from": "agent:bot"},
+             task_id=tid, output={"draft": "unreviewed"})
+    assert r["result"]["state"] == "review_requested"
+    t = coord.workspaces["w"].tasks[tid]
+    assert t.state == "review_requested"
+    assert t.output is None
+    assert t.review.requested_to == ["human:alice"]
+
+    # The eligible reviewer completes it; the producer could not have.
+    a = send("decide.approve", workspace="w", **{"from": "human:alice"}, task_id=tid)
+    assert a["result"]["state"] == "completed"
+    assert coord.workspaces["w"].tasks[tid].output == {"draft": "unreviewed"}
+
+
+def test_task_complete_refused_when_no_eligible_reviewer():
+    coord = Coordinator(CoordinatorOptions(deterministic_ids=True, deterministic_clock=True))
+
+    def send(method, **params):
+        return coord.dispatch({"jsonrpc": "2.0", "id": f"t-{method}",
+                               "method": method, "params": params})
+
+    send("workspace.create", workspace="w",
+         profiles=["core/1.0", "review/1.0", "modes/1.0"])
+    send("participant.join", workspace="w",
+         **{"from": "agent:bot", "type": "agent", "role": "drafter"})
+    tid = send("task.create", workspace="w",
+               **{"from": "agent:bot", "kind": "draft", "input": {},
+                  "assignee": "agent:bot", "mode": "trial"})["result"]["task_id"]
+    send("task.update", workspace="w", **{"from": "agent:bot"},
+         task_id=tid, state="in_progress")
+
+    # The only member is both producer and assignee, so nobody can review. The
+    # producer must not self-approve, so completion is refused, not opened.
+    r = send("task.complete", workspace="w", **{"from": "agent:bot"},
+             task_id=tid, output={"x": 1})
+    assert r["error"]["code"] == -32011  # NOT_AUTHORISED
+    assert coord.workspaces["w"].tasks[tid].state == "in_progress"
+
+
+def test_trial_does_not_force_review_without_modes_profile():
+    coord = Coordinator(CoordinatorOptions(deterministic_ids=True, deterministic_clock=True))
+
+    def send(method, **params):
+        return coord.dispatch({"jsonrpc": "2.0", "id": f"t-{method}",
+                               "method": method, "params": params})
+
+    # Default profiles are core + review, with no modes/1.0.
+    send("workspace.create", workspace="w")
+    send("participant.join", workspace="w",
+         **{"from": "human:alice", "type": "human", "role": "owner"})
+    send("participant.join", workspace="w",
+         **{"from": "agent:bot", "type": "agent", "role": "drafter"})
+    tid = send("task.create", workspace="w",
+               **{"from": "human:alice", "kind": "draft", "input": {},
+                  "assignee": "agent:bot", "mode": "trial"})["result"]["task_id"]
+    # modes/1.0 is not loaded, so trial is inert: review is not forced.
+    assert coord.workspaces["w"].tasks[tid].review_required is None
+    send("task.update", workspace="w", **{"from": "agent:bot"},
+         task_id=tid, state="in_progress")
+    r = send("task.complete", workspace="w", **{"from": "agent:bot"},
+             task_id=tid, output={"ok": 1})
+    assert r["result"]["state"] == "completed"

--- a/packages/coordinator/src/coordinator.ts
+++ b/packages/coordinator/src/coordinator.ts
@@ -921,7 +921,9 @@ export class Coordinator {
     };
 
     // modes/1.0: trial mode forces review
-    if (task.mode === "trial") task.review_required = true;
+    // modes/1.0: trial forces review, but only when the workspace opted into
+    // modes/1.0. mode is inert without the profile.
+    if (ws.profiles.some(pr => pr.startsWith("modes/")) && task.mode === "trial") task.review_required = true;
     else if ("review_required" in p) task.review_required = !!p.review_required;
 
     ws.tasks.set(taskId, task);
@@ -973,6 +975,34 @@ export class Coordinator {
     // can neither revive a terminated task nor bypass a pause.
     if (task.state !== "created" && task.state !== "in_progress") {
       return { error: rpcError(E.PARAMS, `Cannot complete task in state: ${task.state}`) };
+    }
+    // review/1.0 S3.1: task.complete on a task whose review is required opens a
+    // review implicitly rather than completing. The submitted output becomes the
+    // artefact under review; only a reviewer decision (decide.*) then takes the
+    // task to completed. Without this a review_required task would reach
+    // completed with unreviewed output and no decision.
+    if (task.review_required) {
+      const now = this.now();
+      task.pending_artefact = p.output;
+      if (!task.review) {
+        // The producer must not satisfy its own review, so the implicit review
+        // is addressed to the other members, excluding the caller and the
+        // assignee. With nobody eligible there is no independent reviewer, so
+        // refuse rather than open a review only its author could approve. (An
+        // explicit review.request keeps its own `to`.)
+        const producer = p.from as string;
+        const eligible = [...ws.members.keys()].filter(uri => uri !== producer && uri !== task.assignee);
+        if (eligible.length === 0) {
+          return { error: rpcError(E.NOT_AUTHORISED,
+            "Task requires review but has no eligible reviewer (needs a member other than its assignee and completer)") };
+        }
+        task.review = { requested_at: now, requested_to: eligible as ParticipantUri[], rule: "any_one_approves", decisions: [] };
+      }
+      task.state = "review_requested";
+      task.updated_at = now;
+      task.history.push({ ts: now, from: p.from as ParticipantUri, state: "review_requested",
+                          note: "review required; opened on task.complete" });
+      return { result: { state: "review_requested", review_id: task.id } };
     }
     task.output = p.output;
     if (typeof p.confidence === "number" || typeof p.confidence === "string") task.confidence = p.confidence;

--- a/packages/coordinator/src/profiles/control.ts
+++ b/packages/coordinator/src/profiles/control.ts
@@ -204,7 +204,9 @@ export function registerControl(coord: Coordinator): void {
                   note: `supersedes ${old.id}: ${(p.reason as string) || ""}` }],
       paused: false,
     };
-    if (newTask.mode === "trial") newTask.review_required = true;
+    // Trial forces review only when the workspace opted into modes/1.0,
+    // matching task.create -- mode is inert without the profile.
+    if (ws.profiles.some(pr => pr.startsWith("modes/")) && newTask.mode === "trial") newTask.review_required = true;
     else if ("review_required" in newSpec) newTask.review_required = !!newSpec.review_required;
     ws.tasks.set(newId, newTask);
     old.state = "superseded";

--- a/packages/coordinator/tests/profiles.test.ts
+++ b/packages/coordinator/tests/profiles.test.ts
@@ -391,7 +391,8 @@ test("control.supersede forces review on a trial successor", () => {
   const c = new Coordinator({ deterministicIds: true, deterministicClock: true });
   const send = (m: string, p: Record<string, unknown>) =>
     c.dispatch({ jsonrpc: "2.0", id: `t-${m}`, method: m, params: p });
-  send("workspace.create", { workspace: "w", mode_ceiling: "production" });
+  send("workspace.create", { workspace: "w", mode_ceiling: "production",
+    profiles: ["core/1.0", "review/1.0", "modes/1.0"] });
   send("participant.join", { workspace: "w", from: "human:alice", type: "human", role: "owner" });
   send("participant.join", { workspace: "w", from: "agent:bot", type: "agent", role: "drafter" });
   const tid = (send("task.create", { workspace: "w", from: "human:alice", kind: "draft",

--- a/packages/coordinator/tests/review.test.ts
+++ b/packages/coordinator/tests/review.test.ts
@@ -108,3 +108,61 @@ test("task.update cannot complete a task awaiting review", () => {
     task_id: tid, state: "in_progress" });
   assert.equal((withdraw.result as { state: string }).state, "in_progress");
 });
+
+test("task.complete opens a review addressed to the eligible reviewer, not completion", () => {
+  const c = new Coordinator({ deterministicIds: true, deterministicClock: true });
+  const send = (m: string, p: Record<string, unknown>) =>
+    c.dispatch({ jsonrpc: "2.0", id: `t-${m}`, method: m, params: p });
+  send("workspace.create", { workspace: "w", profiles: ["core/1.0", "review/1.0", "modes/1.0"] });
+  send("participant.join", { workspace: "w", from: "human:alice", type: "human", role: "reviewer" });
+  send("participant.join", { workspace: "w", from: "agent:bot", type: "agent", role: "drafter" });
+  const tid = (send("task.create", { workspace: "w", from: "human:alice", kind: "draft",
+    input: {}, assignee: "agent:bot", mode: "trial" }).result as { task_id: string }).task_id;
+  assert.equal(c.workspaces.get("w")!.tasks.get(tid)!.review_required, true);
+  send("task.update", { workspace: "w", from: "agent:bot", task_id: tid, state: "in_progress" });
+
+  const r = send("task.complete", { workspace: "w", from: "agent:bot", task_id: tid,
+    output: { draft: "unreviewed" } });
+  assert.equal((r.result as { state: string }).state, "review_requested");
+  const t = c.workspaces.get("w")!.tasks.get(tid)!;
+  assert.equal(t.state, "review_requested");
+  assert.equal(t.output, undefined);
+  assert.deepEqual(t.review!.requested_to, ["human:alice"]);
+
+  const a = send("decide.approve", { workspace: "w", from: "human:alice", task_id: tid });
+  assert.equal((a.result as { state: string }).state, "completed");
+  assert.deepEqual(c.workspaces.get("w")!.tasks.get(tid)!.output, { draft: "unreviewed" });
+});
+
+test("task.complete is refused when no eligible reviewer exists", () => {
+  const c = new Coordinator({ deterministicIds: true, deterministicClock: true });
+  const send = (m: string, p: Record<string, unknown>) =>
+    c.dispatch({ jsonrpc: "2.0", id: `t-${m}`, method: m, params: p });
+  send("workspace.create", { workspace: "w", profiles: ["core/1.0", "review/1.0", "modes/1.0"] });
+  send("participant.join", { workspace: "w", from: "agent:bot", type: "agent", role: "drafter" });
+  const tid = (send("task.create", { workspace: "w", from: "agent:bot", kind: "draft",
+    input: {}, assignee: "agent:bot", mode: "trial" }).result as { task_id: string }).task_id;
+  send("task.update", { workspace: "w", from: "agent:bot", task_id: tid, state: "in_progress" });
+
+  // Only member is both producer and assignee: nobody can review, so refuse.
+  const r = send("task.complete", { workspace: "w", from: "agent:bot", task_id: tid, output: { x: 1 } });
+  assert.equal(r.error?.code, -32011);  // NOT_AUTHORISED
+  assert.equal(c.workspaces.get("w")!.tasks.get(tid)!.state, "in_progress");
+});
+
+test("trial does not force review without the modes profile", () => {
+  const c = new Coordinator({ deterministicIds: true, deterministicClock: true });
+  const send = (m: string, p: Record<string, unknown>) =>
+    c.dispatch({ jsonrpc: "2.0", id: `t-${m}`, method: m, params: p });
+  // Default profiles are core + review, with no modes/1.0.
+  send("workspace.create", { workspace: "w" });
+  send("participant.join", { workspace: "w", from: "human:alice", type: "human", role: "owner" });
+  send("participant.join", { workspace: "w", from: "agent:bot", type: "agent", role: "drafter" });
+  const tid = (send("task.create", { workspace: "w", from: "human:alice", kind: "draft",
+    input: {}, assignee: "agent:bot", mode: "trial" }).result as { task_id: string }).task_id;
+  // modes/1.0 is not loaded, so trial is inert: review is not forced.
+  assert.equal(c.workspaces.get("w")!.tasks.get(tid)!.review_required, undefined);
+  send("task.update", { workspace: "w", from: "agent:bot", task_id: tid, state: "in_progress" });
+  const r = send("task.complete", { workspace: "w", from: "agent:bot", task_id: tid, output: { ok: 1 } });
+  assert.equal((r.result as { state: string }).state, "completed");
+});


### PR DESCRIPTION
Closes #93. Implements option 2 with the refinements you asked for.

## Breaking change (read first)

For **modes/1.0 workspaces**, `task.complete` on a **trial-mode** task no longer returns `completed`. Trial forces review, so the call now opens a review and the task moves to `review_requested`; a reviewer decision (`decide.approve`/`decide.override`) is what completes it. Any caller that expected `task.complete` to complete a trial task must follow the review. Non-modes workspaces are unaffected.

## What was wrong

`review_required` was set (trial mode, the `task.create` param, `control.supersede`) and serialised, but never read — `task.complete` only checked task state, so a trial task completed with unreviewed output and no decision.

## Changes

1. **modes is inert without the profile.** modes/1.0 is opt-in ("Depends on: Core") and the spec descriptor examples use `mode: production`, yet a default `core/review` workspace defaulted to `trial` and forced review — behaviour nobody opted into. The trial-forcing branch in `task.create` and `control.supersede` is now gated on the workspace having `modes/1.0` loaded. The default stays `trial` for workspaces that *do* opt in (someone choosing modes should start cautious). This is why the ten baseline tests pass untouched.
2. **task.complete enforces review_required** by opening a review implicitly (review/1.0 S3.1) rather than completing. The implicit review is addressed to the members **other than the producer and the assignee**, and the completion is **refused outright when nobody is eligible** — so the producer can never satisfy its own review. An explicit `review.request` keeps its own reviewer set (only the fresh-open path computes eligibility).

Both refs, mirrored. Regression tests: eligible-reviewer open + `decide.approve` completes; refusal when no eligible reviewer; trial inert without modes. The modes-gated supersede test from #92 now loads `modes/1.0`. Full suites green (Python 242, TS 191), typecheck clean; the previously-failing lifecycle/wrap/escalate/confidence tests pass without edits.

## Two points for your call

- **Refusal error code.** The no-eligible-reviewer refusal returns `-32011` (NOT_AUTHORISED) with a clear message. There's no dedicated "no eligible reviewer" code; happy to switch to a new one if you'd prefer.
- **Reviewer eligibility** currently excludes only the producer and assignee, so a second *agent* member can be the reviewer. If trial review should require a human reviewer, say so and I'll narrow it.

Per your note, `control.supersede` gets the same profile gate now that #92 added its trial-forcing branch. The mode-ceiling check is left ungated (it's inert at the default `production` ceiling, and `control.set_mode_ceiling` already requires modes) — tell me if you'd rather gate that too.