### PR TITLE
Evaluate review.rule in decide.approve

### DIFF
--- a/packages/coordinator-py/chap_coordinator/coordinator.py
+++ b/packages/coordinator-py/chap_coordinator/coordinator.py
@@ -239,6 +239,34 @@ def _rehydrate_workspace(data: dict) -> "Workspace":
     return ws
 
 
+def _review_rule_supported(rule: str) -> bool:
+    """Rules review/1.0 can evaluate itself, with no external policy weights."""
+    if rule in ("any_one_approves", "all_approve"):
+        return True
+    if rule.startswith("quorum:"):
+        arg = rule.split(":", 1)[1]
+        return arg.isdigit() and int(arg) >= 1
+    return False
+
+
+def _review_satisfied(review) -> bool:
+    """Whether the approvals recorded so far satisfy the review rule."""
+    approvers = {d["reviewer"] for d in review.decisions
+                 if d.get("kind") == "approve"}
+    rule = review.rule or "any_one_approves"
+    if rule == "all_approve":
+        named = [r for r in review.requested_to
+                 if not (r.startswith("workspace:") or r.startswith("group:"))]
+        # A broadcast-only review has no bounded reviewer set to wait on, so it
+        # degrades to first-approve.
+        if not named:
+            return len(approvers) >= 1
+        return all(r in approvers for r in named)
+    if rule.startswith("quorum:"):
+        return len(approvers) >= int(rule.split(":", 1)[1])
+    return len(approvers) >= 1  # any_one_approves (and the default)
+
+
 _MODE_ORDER = {"shadow": 0, "trial": 1, "production": 2}
 
 
@@ -1063,6 +1091,11 @@ class Coordinator:
             return {"error": rpc_error(E.PARAMS, "review.request needs 'to'")}
         now = self.now_iso()
         rule = p.get("rule") or "any_one_approves"
+        if not _review_rule_supported(rule):
+            return {"error": rpc_error(
+                E.PARAMS,
+                f"Unsupported review rule {rule!r}: review/1.0 supports "
+                "any_one_approves, all_approve, quorum:<n>")}
 
         # A review already open on this task. Replacing the artefact underneath
         # it would let a reviewer decide on content they never saw, and would
@@ -1178,8 +1211,12 @@ class Coordinator:
             "tags": p.get("tags") or [],
         })
         if kind == "approve":
-            task.output = task.pending_artefact
-            task.state = "completed"
+            # Complete only when the review rule's approval predicate is met;
+            # otherwise the approval is recorded and the task stays
+            # review_requested awaiting the rest.
+            if _review_satisfied(task.review):
+                task.output = task.pending_artefact
+                task.state = "completed"
         else:
             task.state = "in_progress" if p.get("request_revision") else "declined"
         task.updated_at = now

--- a/packages/coordinator-py/tests/test_review.py
+++ b/packages/coordinator-py/tests/test_review.py
@@ -122,3 +122,67 @@ def test_task_update_cannot_complete_task_awaiting_review(coord_with_task):
     withdraw = send("task.update", workspace="wsp_r", task_id=tid,
                     **{"from": "agent:bot", "state": "in_progress"})
     assert withdraw["result"]["state"] == "in_progress"
+
+
+def _rule_coord():
+    coord = Coordinator(CoordinatorOptions(deterministic_ids=True, deterministic_clock=True))
+
+    def send(method, **params):
+        return coord.dispatch({"jsonrpc": "2.0", "id": f"t-{method}",
+                               "method": method, "params": params})
+
+    send("workspace.create", workspace="w")
+    for who in ("human:a", "human:b", "human:c"):
+        send("participant.join", workspace="w",
+             **{"from": who, "type": "human", "role": "reviewer"})
+    send("participant.join", workspace="w",
+         **{"from": "agent:bot", "type": "agent", "role": "drafter"})
+    tid = send("task.create", workspace="w",
+               **{"from": "human:a", "kind": "draft", "input": {},
+                  "assignee": "agent:bot"})["result"]["task_id"]
+    return coord, send, tid
+
+
+def test_all_approve_requires_every_named_reviewer():
+    coord, send, tid = _rule_coord()
+    send("review.request", workspace="w",
+         **{"from": "agent:bot", "to": ["human:a", "human:b", "human:c"]},
+         task_id=tid, artefact={"x": 1}, rule="all_approve")
+    assert send("decide.approve", workspace="w", **{"from": "human:a"},
+                task_id=tid)["result"]["state"] == "review_requested"
+    assert send("decide.approve", workspace="w", **{"from": "human:b"},
+                task_id=tid)["result"]["state"] == "review_requested"
+    assert send("decide.approve", workspace="w", **{"from": "human:c"},
+                task_id=tid)["result"]["state"] == "completed"
+
+
+def test_all_approve_ignores_a_duplicate_approval():
+    coord, send, tid = _rule_coord()
+    send("review.request", workspace="w",
+         **{"from": "agent:bot", "to": ["human:a", "human:b"]},
+         task_id=tid, artefact={"x": 1}, rule="all_approve")
+    send("decide.approve", workspace="w", **{"from": "human:a"}, task_id=tid)
+    # A second approval from the same reviewer must not satisfy all_approve.
+    assert send("decide.approve", workspace="w", **{"from": "human:a"},
+                task_id=tid)["result"]["state"] == "review_requested"
+    assert send("decide.approve", workspace="w", **{"from": "human:b"},
+                task_id=tid)["result"]["state"] == "completed"
+
+
+def test_quorum_completes_at_n_distinct_approvers():
+    coord, send, tid = _rule_coord()
+    send("review.request", workspace="w",
+         **{"from": "agent:bot", "to": ["human:a", "human:b", "human:c"]},
+         task_id=tid, artefact={"x": 1}, rule="quorum:2")
+    assert send("decide.approve", workspace="w", **{"from": "human:a"},
+                task_id=tid)["result"]["state"] == "review_requested"
+    assert send("decide.approve", workspace="w", **{"from": "human:b"},
+                task_id=tid)["result"]["state"] == "completed"
+
+
+def test_review_request_rejects_unhonorable_rule():
+    coord, send, tid = _rule_coord()
+    r = send("review.request", workspace="w",
+             **{"from": "agent:bot", "to": ["human:a"]},
+             task_id=tid, artefact={"x": 1}, rule="weighted_vote:2.0")
+    assert r["error"]["code"] == -32602  # PARAMS: rule review/1.0 can't honor

--- a/packages/coordinator/src/coordinator.ts
+++ b/packages/coordinator/src/coordinator.ts
@@ -147,6 +147,29 @@ function linkHash(envelope: Envelope, prev: string): string {
   return sha256Hex(Buffer.concat([canonicalize(envelope), Buffer.from(prev, "utf-8")]));
 }
 
+function reviewRuleSupported(rule: string): boolean {
+  if (rule === "any_one_approves" || rule === "all_approve") return true;
+  if (rule.startsWith("quorum:")) {
+    const arg = rule.slice("quorum:".length);
+    return /^[0-9]+$/.test(arg) && parseInt(arg, 10) >= 1;
+  }
+  return false;
+}
+
+function reviewSatisfied(review: { requested_to: string[]; rule: string; decisions: { kind: string; reviewer: string }[] }): boolean {
+  const approvers = new Set(review.decisions.filter(d => d.kind === "approve").map(d => d.reviewer));
+  const rule = review.rule || "any_one_approves";
+  if (rule === "all_approve") {
+    // A broadcast-only review has no bounded reviewer set to wait on, so it
+    // degrades to first-approve.
+    const named = review.requested_to.filter(r => !(r.startsWith("workspace:") || r.startsWith("group:")));
+    if (named.length === 0) return approvers.size >= 1;
+    return named.every(r => approvers.has(r));
+  }
+  if (rule.startsWith("quorum:")) return approvers.size >= parseInt(rule.slice("quorum:".length), 10);
+  return approvers.size >= 1;  // any_one_approves (and the default)
+}
+
 function reply(env: Envelope, body: { result?: unknown; error?: { code: number; message: string; data?: unknown } }): Envelope {
   const out: Envelope = { jsonrpc: "2.0", id: env.id };
   if (body.error !== undefined) out.error = body.error;
@@ -1026,6 +1049,9 @@ export class Coordinator {
     if (!reviewers.length) return { error: rpcError(E.PARAMS, "review.request needs 'to'") };
     const now = this.now();
     const rule = (p.rule as string) || "any_one_approves";
+    if (!reviewRuleSupported(rule)) {
+      return { error: rpcError(E.PARAMS, `Unsupported review rule ${JSON.stringify(rule)}: review/1.0 supports any_one_approves, all_approve, quorum:<n>`) };
+    }
 
     // A review already open on this task. Replacing the artefact underneath
     // it would let a reviewer decide on content they never saw, and would
@@ -1135,8 +1161,12 @@ export class Coordinator {
       tags: p.tags as string[] | undefined,
     });
     if (kind === "approve") {
-      task.output = task.pending_artefact;
-      task.state = "completed";
+      // Complete only when the rule's approval predicate is met; otherwise the
+      // approval is recorded and the task stays review_requested.
+      if (reviewSatisfied(task.review!)) {
+        task.output = task.pending_artefact;
+        task.state = "completed";
+      }
     } else {
       task.state = p.request_revision ? "in_progress" : "declined";
     }

--- a/packages/coordinator/tests/review.test.ts
+++ b/packages/coordinator/tests/review.test.ts
@@ -108,3 +108,50 @@ test("task.update cannot complete a task awaiting review", () => {
     task_id: tid, state: "in_progress" });
   assert.equal((withdraw.result as { state: string }).state, "in_progress");
 });
+
+function ruleSetup() {
+  const c = new Coordinator({ deterministicIds: true, deterministicClock: true });
+  const send = (m: string, p: Record<string, unknown>) =>
+    c.dispatch({ jsonrpc: "2.0", id: `t-${m}`, method: m, params: p });
+  send("workspace.create", { workspace: "w" });
+  for (const who of ["human:a", "human:b", "human:c"])
+    send("participant.join", { workspace: "w", from: who, type: "human", role: "reviewer" });
+  send("participant.join", { workspace: "w", from: "agent:bot", type: "agent", role: "drafter" });
+  const tid = (send("task.create", { workspace: "w", from: "human:a", kind: "draft",
+    input: {}, assignee: "agent:bot" }).result as { task_id: string }).task_id;
+  const st = (r: ReturnType<Coordinator["dispatch"]>) => (r.result as { state: string }).state;
+  return { c, send, tid, st };
+}
+
+test("all_approve requires every named reviewer to approve", () => {
+  const { send, tid, st } = ruleSetup();
+  send("review.request", { workspace: "w", from: "agent:bot",
+    to: ["human:a", "human:b", "human:c"], task_id: tid, artefact: { x: 1 }, rule: "all_approve" });
+  assert.equal(st(send("decide.approve", { workspace: "w", from: "human:a", task_id: tid })), "review_requested");
+  assert.equal(st(send("decide.approve", { workspace: "w", from: "human:b", task_id: tid })), "review_requested");
+  assert.equal(st(send("decide.approve", { workspace: "w", from: "human:c", task_id: tid })), "completed");
+});
+
+test("all_approve ignores a duplicate approval from the same reviewer", () => {
+  const { send, tid, st } = ruleSetup();
+  send("review.request", { workspace: "w", from: "agent:bot",
+    to: ["human:a", "human:b"], task_id: tid, artefact: { x: 1 }, rule: "all_approve" });
+  send("decide.approve", { workspace: "w", from: "human:a", task_id: tid });
+  assert.equal(st(send("decide.approve", { workspace: "w", from: "human:a", task_id: tid })), "review_requested");
+  assert.equal(st(send("decide.approve", { workspace: "w", from: "human:b", task_id: tid })), "completed");
+});
+
+test("quorum completes at N distinct approvers", () => {
+  const { send, tid, st } = ruleSetup();
+  send("review.request", { workspace: "w", from: "agent:bot",
+    to: ["human:a", "human:b", "human:c"], task_id: tid, artefact: { x: 1 }, rule: "quorum:2" });
+  assert.equal(st(send("decide.approve", { workspace: "w", from: "human:a", task_id: tid })), "review_requested");
+  assert.equal(st(send("decide.approve", { workspace: "w", from: "human:b", task_id: tid })), "completed");
+});
+
+test("review.request rejects a rule review/1.0 cannot honor", () => {
+  const { send, tid } = ruleSetup();
+  const r = send("review.request", { workspace: "w", from: "agent:bot",
+    to: ["human:a"], task_id: tid, artefact: { x: 1 }, rule: "weighted_vote:2.0" });
+  assert.equal(r.error?.code, -32602);
+});


### PR DESCRIPTION
Closes #98.

`decide.approve` completed the task on the **first** approval regardless of `review.rule` — the rule was only consulted to reject a rule *change* on an open review. So `all_approve` and `quorum` reviews were satisfiable by one reviewer (review.md:145 makes the rule normative for how many must decide; SPEC §8.3).

## Changes (both refs)

- `decide.approve` completes only when the rule's approval predicate is met over the **distinct approvers** so far; otherwise it records the approval and the task stays `review_requested`:
  - `any_one_approves`: ≥1 (unchanged)
  - `all_approve`: every **named** reviewer in `requested_to` has approved (a broadcast-only review has no bounded set, so it degrades to first-approve)
  - `quorum:<n>`: ≥ n distinct approvers
- `review.request` validates `rule` and rejects one review/1.0 can't evaluate on its own (`weighted_vote*`, malformed) with `-32602`, so a rule the decide path would silently ignore can never be opened.

`decide.override` stays decisive; `any_one_approves` (the default) is unchanged, so existing default-rule review tests pass untouched. Regression tests cover all_approve (incl. duplicate-approval), quorum, and the rule rejection — all fail on pre-fix `main`. Full suites green (Python 243, TS 192), typecheck clean.

## The two design questions from #98 still stand
1. **Weighted review rules** — review/1.0 has no policy weights, so this PR rejects them at `review.request`. If weighted reviews should be supported via `deliberation`, that's a separate change.
2. **override under `all_approve`** — kept decisive (completes immediately). Say if you'd rather it wait.