### PR TITLE
Treat superseded as terminal in control.pause/cancel

### DIFF
--- a/packages/coordinator-py/chap_coordinator/profiles/control.py
+++ b/packages/coordinator-py/chap_coordinator/profiles/control.py
@@ -52,7 +52,7 @@ def register_control(coord: "Coordinator") -> None:
             task = ws.tasks.get(p.get("task_id", ""))
             if not task:
                 return {"error": rpc_error(E.PARAMS, "Unknown task")}
-            if task.state in ("completed", "declined", "cancelled"):
+            if task.state in ("completed", "declined", "cancelled", "superseded"):
                 return {"error": rpc_error(E.CONTROL_NOT_AUTHORISED,
                                            f"Cannot pause {task.state} task")}
             task.paused = True
@@ -126,7 +126,7 @@ def register_control(coord: "Coordinator") -> None:
         task = ws.tasks.get(p.get("task_id", ""))
         if not task:
             return {"error": rpc_error(E.PARAMS, "Unknown task")}
-        if task.state in ("completed", "declined", "cancelled"):
+        if task.state in ("completed", "declined", "cancelled", "superseded"):
             return {"error": rpc_error(E.CONTROL_NOT_AUTHORISED,
                                        f"Cannot cancel {task.state} task")}
         task.state = "cancelled"
@@ -150,7 +150,7 @@ def register_control(coord: "Coordinator") -> None:
         if "open_tasks" in include:
             state["open_tasks"] = [
                 t.to_dict() for t in ws.tasks.values()
-                if t.state not in ("completed", "declined", "cancelled")
+                if t.state not in ("completed", "declined", "cancelled", "superseded")
             ]
         if "mode_ceiling" in include:
             state["mode_ceiling"] = ws.mode_ceiling

--- a/packages/coordinator-py/tests/test_profiles.py
+++ b/packages/coordinator-py/tests/test_profiles.py
@@ -474,3 +474,30 @@ def test_supersede_trial_forces_review():
                                           "mode": "trial", "review_required": False})
     new_id = r["result"]["new_task_id"]
     assert coord.workspaces["w"].tasks[new_id].review_required is True
+
+
+def test_pause_cancel_reject_a_superseded_task():
+    coord = Coordinator(CoordinatorOptions(deterministic_ids=True, deterministic_clock=True))
+
+    def send(method, **params):
+        return coord.dispatch({"jsonrpc": "2.0", "id": f"t-{method}",
+                               "method": method, "params": params})
+
+    send("workspace.create", workspace="w")
+    send("participant.join", workspace="w",
+         **{"from": "human:alice", "type": "human", "role": "owner"})
+    send("participant.join", workspace="w",
+         **{"from": "agent:bot", "type": "agent", "role": "drafter"})
+    tid = send("task.create", workspace="w",
+               **{"from": "human:alice", "kind": "k", "input": {},
+                  "assignee": "agent:bot"})["result"]["task_id"]
+    send("control.supersede", workspace="w", **{"from": "human:alice"},
+         task_id=tid, successor_task={"kind": "k", "assignee": "agent:bot"})
+    assert coord.workspaces["w"].tasks[tid].state == "superseded"
+
+    # superseded is terminal (SPEC §8.1): it cannot be paused or cancelled.
+    assert "error" in send("control.pause", workspace="w",
+                           **{"from": "human:alice"}, task_id=tid)
+    assert "error" in send("control.cancel", workspace="w",
+                           **{"from": "human:alice"}, task_id=tid)
+    assert coord.workspaces["w"].tasks[tid].state == "superseded"

--- a/packages/coordinator/src/profiles/control.ts
+++ b/packages/coordinator/src/profiles/control.ts
@@ -28,7 +28,7 @@ export function registerControl(coord: Coordinator): void {
     if (scope === "task") {
       const task = ws.tasks.get(p.task_id as string);
       if (!task) return { error: rpcError(E.PARAMS, "Unknown task") };
-      if (task.state === "completed" || task.state === "declined" || task.state === "cancelled") {
+      if (task.state === "completed" || task.state === "declined" || task.state === "cancelled" || task.state === "superseded") {
         return { error: rpcError(E.CONTROL_NOT_AUTHORISED, `Cannot pause ${task.state} task`) };
       }
       task.paused = true;
@@ -86,7 +86,7 @@ export function registerControl(coord: Coordinator): void {
     if (!ws) return { error: rpcError(E.PARAMS, "Unknown workspace") };
     const task = ws.tasks.get(p.task_id as string);
     if (!task) return { error: rpcError(E.PARAMS, "Unknown task") };
-    if (task.state === "completed" || task.state === "declined" || task.state === "cancelled") {
+    if (task.state === "completed" || task.state === "declined" || task.state === "cancelled" || task.state === "superseded") {
       return { error: rpcError(E.CONTROL_NOT_AUTHORISED, `Cannot cancel ${task.state} task`) };
     }
     task.state = "cancelled";
@@ -107,7 +107,7 @@ export function registerControl(coord: Coordinator): void {
     }
     if (include.includes("open_tasks")) {
       state.open_tasks = Array.from(ws.tasks.values())
-        .filter(t => t.state !== "completed" && t.state !== "declined" && t.state !== "cancelled")
+        .filter(t => t.state !== "completed" && t.state !== "declined" && t.state !== "cancelled" && t.state !== "superseded")
         .map(t => ({ id: t.id, kind: t.kind, state: t.state, assignee: t.assignee }));
     }
     if (include.includes("mode_ceiling")) state.mode_ceiling = ws.mode_ceiling;

--- a/packages/coordinator/tests/profiles.test.ts
+++ b/packages/coordinator/tests/profiles.test.ts
@@ -402,3 +402,22 @@ test("control.supersede forces review on a trial successor", () => {
   const newId = (r.result as { new_task_id: string }).new_task_id;
   assert.equal(c.workspaces.get("w")!.tasks.get(newId)!.review_required, true);
 });
+
+test("control.pause/cancel reject a superseded task", () => {
+  const c = new Coordinator({ deterministicIds: true, deterministicClock: true });
+  const send = (m: string, p: Record<string, unknown>) =>
+    c.dispatch({ jsonrpc: "2.0", id: `t-${m}`, method: m, params: p });
+  send("workspace.create", { workspace: "w" });
+  send("participant.join", { workspace: "w", from: "human:alice", type: "human", role: "owner" });
+  send("participant.join", { workspace: "w", from: "agent:bot", type: "agent", role: "drafter" });
+  const tid = (send("task.create", { workspace: "w", from: "human:alice", kind: "k",
+    input: {}, assignee: "agent:bot" }).result as { task_id: string }).task_id;
+  send("control.supersede", { workspace: "w", from: "human:alice", task_id: tid,
+    successor_task: { kind: "k", assignee: "agent:bot" } });
+  assert.equal(c.workspaces.get("w")!.tasks.get(tid)!.state, "superseded");
+
+  // superseded is terminal (SPEC §8.1): it cannot be paused or cancelled.
+  assert.ok(send("control.pause", { workspace: "w", from: "human:alice", task_id: tid }).error);
+  assert.ok(send("control.cancel", { workspace: "w", from: "human:alice", task_id: tid }).error);
+  assert.equal(c.workspaces.get("w")!.tasks.get(tid)!.state, "superseded");
+});


### PR DESCRIPTION
Closes #100.

The pause and cancel guards blocked `completed`/`declined`/`cancelled` but not `superseded`, which SPEC §8.1 also lists as terminal, so a superseded task could be paused (resurrected) or cancelled. The snapshot `open_tasks` filter had the same omission.

Adds `superseded` to the pause guard, the cancel guard, and the snapshot filter in both refs. Regression test: supersede a task, then pause/cancel must both error and it stays `superseded` — fails on pre-fix `main`. Full suites green (Python 240, TS 189), typecheck clean.

`declined` is left in the guards (non-terminal per §8.1, so over-strict but harmless — not changing it here).