### PR TITLE
Parse JSON Patch array indices with one strict shared rule

### DIFF
--- a/packages/coordinator-py/chap_coordinator/patch.py
+++ b/packages/coordinator-py/chap_coordinator/patch.py
@@ -16,12 +16,25 @@ exactly the same patches.
 from __future__ import annotations
 
 import copy
+import re
 from typing import Any
 
 # Rejected in every JSON Pointer segment. In a JavaScript runtime these
 # enable prototype pollution; CHAP refuses them in both references so a
 # patch refused by one implementation is refused by the other.
 _DANGEROUS_KEYS = frozenset({"__proto__", "constructor", "prototype"})
+
+# An array index is an RFC 6901 array index: "0" or a positive integer with no
+# leading zero. A shared strict rule keeps the two references in step -- JS
+# Number() and Python int() otherwise accept disjoint token sets (e.g. "1e1",
+# "0x0a", "3.0", "", "1_0"), which would apply the same patch differently.
+_ARRAY_INDEX_RE = re.compile(r"^(0|[1-9][0-9]*)$")
+
+
+def _array_index(seg: str) -> int:
+    if not _ARRAY_INDEX_RE.match(seg):
+        raise PatchError(f"Array index expected at {seg!r}")
+    return int(seg)
 
 
 class PatchError(Exception):
@@ -52,11 +65,8 @@ def _navigate(doc: Any, parts: list[str]) -> tuple[Any, str | int]:
     parent = doc
     for i, part in enumerate(parts[:-1]):
         if isinstance(parent, list):
-            try:
-                idx = int(part)
-            except ValueError as exc:
-                raise PatchError(f"Array index expected at {part!r}") from exc
-            if idx < 0 or idx >= len(parent):
+            idx = _array_index(part)
+            if idx >= len(parent):
                 raise PatchError(f"Index out of range at /{'/'.join(parts[:i+1])}")
             parent = parent[idx]
         elif isinstance(parent, dict):
@@ -69,10 +79,7 @@ def _navigate(doc: Any, parts: list[str]) -> tuple[Any, str | int]:
     if isinstance(parent, list):
         if last == "-":
             return parent, "-"  # append marker
-        try:
-            return parent, int(last)
-        except ValueError as exc:
-            raise PatchError(f"Array index expected at {last!r}") from exc
+        return parent, _array_index(last)
     return parent, last
 
 

--- a/packages/coordinator-py/tests/test_patch_vectors.py
+++ b/packages/coordinator-py/tests/test_patch_vectors.py
@@ -45,3 +45,23 @@ def test_prototype_pollution_does_not_leak():
     with pytest.raises(PatchError):
         apply_json_patch({}, [{"op": "add", "path": "/__proto__/polluted", "value": "x"}])
     assert not hasattr(dict, "polluted")
+
+
+@pytest.mark.parametrize("bad", [
+    "/items/1e1", "/items/0x0a", "/items/3.0", "/items/", "/items/1_0", "/items/01",
+])
+def test_non_canonical_array_index_is_rejected(bad):
+    # These tokens are accepted by JS Number() or Python int() but not both;
+    # a strict shared rule must reject them all so the two references agree.
+    with pytest.raises(PatchError):
+        apply_json_patch({"items": [10, 20, 30]},
+                         [{"op": "replace", "path": bad, "value": 99}])
+
+
+def test_canonical_array_index_still_applies():
+    assert apply_json_patch({"items": [10, 20, 30]},
+                            [{"op": "replace", "path": "/items/1", "value": 99}]) \
+        == {"items": [10, 99, 30]}
+    assert apply_json_patch({"items": [10, 20, 30]},
+                            [{"op": "add", "path": "/items/-", "value": 40}]) \
+        == {"items": [10, 20, 30, 40]}

--- a/packages/coordinator/src/patch.ts
+++ b/packages/coordinator/src/patch.ts
@@ -20,6 +20,17 @@ export class PatchError extends Error {}
 // Rejected in every JSON Pointer segment: these enable prototype pollution.
 const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 
+// An array index is an RFC 6901 array index: "0" or a positive integer with no
+// leading zero. A shared strict rule keeps the two references in step -- JS
+// Number() and Python int() otherwise accept disjoint token sets (e.g. "1e1",
+// "0x0a", "3.0", "", "1_0"), which would apply the same patch differently.
+const ARRAY_INDEX_RE = /^(0|[1-9][0-9]*)$/;
+
+function arrayIndex(seg: string): number {
+  if (!ARRAY_INDEX_RE.test(seg)) throw new PatchError(`Array index expected at ${JSON.stringify(seg)}`);
+  return Number(seg);
+}
+
 function unescape(token: string): string {
   return token.replace(/~1/g, "/").replace(/~0/g, "~");
 }
@@ -47,8 +58,8 @@ function navigate(doc: any, parts: string[]): [any, string | number] {
   for (let i = 0; i < parts.length - 1; i++) {
     const part = parts[i];
     if (Array.isArray(parent)) {
-      const idx = Number(part);
-      if (!Number.isInteger(idx) || idx < 0 || idx >= parent.length) {
+      const idx = arrayIndex(part);
+      if (idx >= parent.length) {
         throw new PatchError(`Index out of range at /${parts.slice(0, i + 1).join("/")}`);
       }
       parent = parent[idx];
@@ -64,11 +75,7 @@ function navigate(doc: any, parts: string[]): [any, string | number] {
   const last = parts[parts.length - 1];
   if (Array.isArray(parent)) {
     if (last === "-") return [parent, "-"];
-    const idx = Number(last);
-    if (!Number.isInteger(idx)) {
-      throw new PatchError(`Array index expected at ${JSON.stringify(last)}`);
-    }
-    return [parent, idx];
+    return [parent, arrayIndex(last)];
   }
   return [parent, last];
 }

--- a/packages/coordinator/tests/patch_vectors.test.ts
+++ b/packages/coordinator/tests/patch_vectors.test.ts
@@ -46,3 +46,19 @@ test("prototype pollution does not leak to Object.prototype", () => {
   );
   assert.equal(({} as Record<string, unknown>).polluted, undefined);
 });
+
+for (const bad of ["/items/1e1", "/items/0x0a", "/items/3.0", "/items/", "/items/1_0", "/items/01"]) {
+  test(`non-canonical array index ${JSON.stringify(bad)} is rejected`, () => {
+    // Accepted by JS Number() or Python int() but not both; a strict shared
+    // rule must reject them all so the two references agree.
+    assert.throws(() => applyJsonPatch({ items: [10, 20, 30] },
+      [{ op: "replace", path: bad, value: 99 }] as never));
+  });
+}
+
+test("canonical array index still applies", () => {
+  assert.deepEqual(applyJsonPatch({ items: [10, 20, 30] },
+    [{ op: "replace", path: "/items/1", value: 99 }] as never), { items: [10, 99, 30] });
+  assert.deepEqual(applyJsonPatch({ items: [10, 20, 30] },
+    [{ op: "add", path: "/items/-", value: 40 }] as never), { items: [10, 20, 30, 40] });
+});


### PR DESCRIPTION
Closes #102.

`patch.ts` parsed array-index segments with `Number()` and `patch.py` with `int()`; the two accept disjoint token sets (`1e1`, `0x0a`, `3.0`, empty, `1_0`, leading zeros), so the same `decide.override` patch could apply on one coordinator and be rejected/misapplied on the other — a byte-identical-chain consensus break.

Both now parse an index with the RFC 6901 rule `^(0|[1-9][0-9]*)$` and reject anything else identically; `-` append is unchanged. Regression tests (shared token list) reject the non-canonical forms and keep canonical indices + `-` working; they fail on pre-fix code (Python on `01`, TS on empty). Full suites green (Python 246, TS 195), typecheck clean.