### PR TITLE
Require workspace membership for whisper.* methods

### DIFF
--- a/packages/coordinator-py/chap_coordinator/coordinator.py
+++ b/packages/coordinator-py/chap_coordinator/coordinator.py
@@ -433,7 +433,8 @@ class Coordinator:
         # Deployments needing a stricter role gate than membership layer it on
         # top via an identity-* profile or application check.)
         if (method.startswith("control.") or method.startswith("deliberate.")
-                or method.startswith("handoff.")):
+                or method.startswith("handoff.")
+                or method.startswith("whisper.")):
             ws_id = params.get("workspace") if isinstance(params, dict) else None
             ws = self.workspaces.get(ws_id) if isinstance(ws_id, str) else None
             if ws is not None:

--- a/packages/coordinator-py/tests/test_profiles.py
+++ b/packages/coordinator-py/tests/test_profiles.py
@@ -474,3 +474,26 @@ def test_supersede_trial_forces_review():
                                           "mode": "trial", "review_required": False})
     new_id = r["result"]["new_task_id"]
     assert coord.workspaces["w"].tasks[new_id].review_required is True
+
+
+def test_whisper_ask_requires_membership():
+    coord = Coordinator(CoordinatorOptions(deterministic_ids=True, deterministic_clock=True))
+
+    def send(method, **params):
+        return coord.dispatch({"jsonrpc": "2.0", "id": f"t-{method}",
+                               "method": method, "params": params})
+
+    send("workspace.create", workspace="w")
+    send("participant.join", workspace="w",
+         **{"from": "human:alice", "type": "human", "role": "owner"})
+    send("participant.join", workspace="w",
+         **{"from": "agent:bot", "type": "agent", "role": "drafter"})
+    tid = send("task.create", workspace="w",
+               **{"from": "human:alice", "kind": "k", "input": {},
+                  "assignee": "agent:bot"})["result"]["task_id"]
+    # A non-member cannot ask a whisper (SPEC §6.3.1).
+    r = send("whisper.ask", workspace="w",
+             **{"from": "human:outsider", "to": ["human:alice"]},
+             task_id=tid, question="?", options=[{"id": "y"}],
+             deadline_ms=30000, default_if_lapsed="y")
+    assert r["error"]["code"] == -32011  # NOT_AUTHORISED

--- a/packages/coordinator/src/coordinator.ts
+++ b/packages/coordinator/src/coordinator.ts
@@ -467,7 +467,7 @@ export class Coordinator {
     // deliberation to finalize an outcome early. (The per-voter eligibility
     // check in deliberate.vote is separate and still applies. A stricter role
     // gate than membership is layered on top via an identity-* profile.)
-    if (method.startsWith("control.") || method.startsWith("deliberate.") || method.startsWith("handoff.")) {
+    if (method.startsWith("control.") || method.startsWith("deliberate.") || method.startsWith("handoff.") || method.startsWith("whisper.")) {
       const wsId = params.workspace as string | undefined;
       const ws = typeof wsId === "string" ? this.workspaces.get(wsId) : undefined;
       if (ws) {

--- a/packages/coordinator/tests/profiles.test.ts
+++ b/packages/coordinator/tests/profiles.test.ts
@@ -402,3 +402,18 @@ test("control.supersede forces review on a trial successor", () => {
   const newId = (r.result as { new_task_id: string }).new_task_id;
   assert.equal(c.workspaces.get("w")!.tasks.get(newId)!.review_required, true);
 });
+
+test("whisper.ask requires the asker to be a member", () => {
+  const c = new Coordinator({ deterministicIds: true, deterministicClock: true });
+  const send = (m: string, p: Record<string, unknown>) =>
+    c.dispatch({ jsonrpc: "2.0", id: `t-${m}`, method: m, params: p });
+  send("workspace.create", { workspace: "w" });
+  send("participant.join", { workspace: "w", from: "human:alice", type: "human", role: "owner" });
+  send("participant.join", { workspace: "w", from: "agent:bot", type: "agent", role: "drafter" });
+  const tid = (send("task.create", { workspace: "w", from: "human:alice", kind: "k",
+    input: {}, assignee: "agent:bot" }).result as { task_id: string }).task_id;
+  // A non-member cannot ask a whisper (SPEC §6.3.1).
+  const r = send("whisper.ask", { workspace: "w", from: "human:outsider", to: ["human:alice"],
+    task_id: tid, question: "?", options: [{ id: "y" }], deadline_ms: 30000, default_if_lapsed: "y" });
+  assert.equal(r.error?.code, -32011);
+});


### PR DESCRIPTION
Closes #104.

`whisper.ask`/`whisper.answer` carry a `from` actor but were not under the dispatch membership floor, so a non-member could ask a whisper (§6.3.1). Adds `whisper.` to the floor alongside `control.`/`deliberate.`/`handoff.`. Regression test: a non-member asker → `-32011`; fails on pre-fix `main`. Full suites green (Python 240, TS 189), typecheck clean; the existing whisper askee-eligibility tests are unaffected.

Scope note: the routing methods (`task.route`, `review.depth`, `escalate.auto`) are part of the same audit finding but are actor-less by design (no `from`), so they are a separate question — raised in #104 companion issue, not changed here.