### PR TITLE
Enforce and publish a maximum envelope size

### DIFF
--- a/packages/coordinator-py/chap_coordinator/coordinator.py
+++ b/packages/coordinator-py/chap_coordinator/coordinator.py
@@ -107,6 +107,10 @@ class CoordinatorOptions:
     default: reads are transport-delegated. Enable for multi-tenant or
     directly-exposed deployments."""
 
+    max_envelope_bytes: int = 1_048_576
+    """Largest envelope accepted, published in the workspace descriptor
+    (SPEC S4.4). Envelopes whose canonical form exceeds this are rejected."""
+
     on_audit: AuditListener | None = None
     """Called after every successfully recorded audit entry."""
 
@@ -380,6 +384,19 @@ class Coordinator:
             return make_response(
                 envelope.get("id") if isinstance(envelope, dict) else None,
                 error=rpc_error(E.REQUEST, "Invalid JSON-RPC 2.0 request"),
+            )
+
+        try:
+            size = len(canonicalize(envelope))
+        except (ValueError, TypeError):
+            size = 0  # not canonicalisable; the ingress check below rejects it
+        if size > self.options.max_envelope_bytes:
+            return make_response(
+                envelope.get("id"),
+                error=rpc_error(
+                    E.REQUEST,
+                    f"Envelope exceeds max_envelope_bytes "
+                    f"({size} > {self.options.max_envelope_bytes})"),
             )
 
         method = envelope.get("method")
@@ -764,6 +781,7 @@ class Coordinator:
             "state": ws.state,
             "mode": ws.mode,
             "mode_ceiling": ws.mode_ceiling,
+            "max_envelope_bytes": self.options.max_envelope_bytes,
             "step_up_window_sec": ws.step_up_window_sec,
             "profiles": ws.profiles,
             "members": [m.to_dict() for m in ws.members.values()],

--- a/packages/coordinator-py/tests/test_core.py
+++ b/packages/coordinator-py/tests/test_core.py
@@ -102,3 +102,22 @@ def test_unknown_method(coord):
 def test_malformed_envelope(coord):
     r = coord.dispatch({"not_jsonrpc": True})
     assert "error" in r and r["error"]["code"] == -32600
+
+
+def test_oversized_envelope_is_rejected():
+    coord = Coordinator(CoordinatorOptions(max_envelope_bytes=200))
+    ok = coord.dispatch({"jsonrpc": "2.0", "id": "1",
+                         "method": "workspace.create", "params": {"workspace": "w"}})
+    assert "result" in ok
+    big = coord.dispatch({"jsonrpc": "2.0", "id": "2", "method": "workspace.describe",
+                          "params": {"workspace": "w", "pad": "x" * 500}})
+    assert big["error"]["code"] == -32600  # REQUEST
+
+
+def test_describe_publishes_max_envelope_bytes():
+    coord = Coordinator(CoordinatorOptions())
+    coord.dispatch({"jsonrpc": "2.0", "id": "1",
+                    "method": "workspace.create", "params": {"workspace": "w"}})
+    d = coord.dispatch({"jsonrpc": "2.0", "id": "2",
+                        "method": "workspace.describe", "params": {"workspace": "w"}})
+    assert d["result"]["max_envelope_bytes"] == 1048576

--- a/packages/coordinator/src/coordinator.ts
+++ b/packages/coordinator/src/coordinator.ts
@@ -94,6 +94,9 @@ const READ_ONLY_METHODS = new Set<string>([
 // workspace; a redelivery beyond this many intervening creates is not deduped.
 const MAX_IDEMPOTENCY_KEYS = 10_000;
 
+// Largest envelope accepted, published in the workspace descriptor (SPEC S4.4).
+const DEFAULT_MAX_ENVELOPE_BYTES = 1_048_576;
+
 export interface CoordinatorOptions {
   deterministicIds?: boolean;
   deterministicClock?: boolean;
@@ -101,6 +104,8 @@ export interface CoordinatorOptions {
   requireSignatures?: boolean;
   enforceStepUp?: boolean;
   requireReadMembership?: boolean;
+  /** Largest envelope accepted (default 1 MiB), published in the descriptor. */
+  maxEnvelopeBytes?: number;
   onAudit?: AuditListener;
   onAutoEscalate?: (task: Task, to: ParticipantUri) => void;
   verifyOidcToken?: TokenVerifier;
@@ -421,6 +426,13 @@ export class Coordinator {
   dispatch(envelope: Envelope): Envelope {
     if (!isValidEnvelope(envelope) || !envelope.method) {
       return reply(envelope, { error: rpcError(E.REQUEST, "Invalid JSON-RPC 2.0 request") });
+    }
+    const maxBytes = this.options.maxEnvelopeBytes ?? DEFAULT_MAX_ENVELOPE_BYTES;
+    let size = 0;
+    try { size = canonicalize(envelope).length; } catch { /* not canonicalisable; rejected by the ingress check below */ }
+    if (size > maxBytes) {
+      return reply(envelope, { error: rpcError(E.REQUEST,
+        `Envelope exceeds max_envelope_bytes (${size} > ${maxBytes})`) });
     }
     const method = envelope.method;
     // JSON-RPC params, when present, must be a structured value (object).
@@ -761,6 +773,7 @@ export class Coordinator {
       state: ws.state,
       mode: ws.mode,
       mode_ceiling: ws.mode_ceiling,
+      max_envelope_bytes: this.options.maxEnvelopeBytes ?? DEFAULT_MAX_ENVELOPE_BYTES,
       step_up_window_sec: ws.step_up_window_sec,
       profiles: ws.profiles,
       members: Array.from(ws.members.values()).map(memberToDict),

--- a/packages/coordinator/tests/core.test.ts
+++ b/packages/coordinator/tests/core.test.ts
@@ -92,3 +92,19 @@ test("malformed envelope returns -32600", () => {
   const r = c.dispatch({ not_jsonrpc: true } as never);
   assert.equal(r.error?.code, -32600);
 });
+
+test("an oversized envelope is rejected", () => {
+  const c = new Coordinator({ maxEnvelopeBytes: 200 });
+  const ok = c.dispatch({ jsonrpc: "2.0", id: "1", method: "workspace.create", params: { workspace: "w" } });
+  assert.ok("result" in ok && !ok.error);
+  const big = c.dispatch({ jsonrpc: "2.0", id: "2", method: "workspace.describe",
+    params: { workspace: "w", pad: "x".repeat(500) } } as never);
+  assert.equal(big.error?.code, -32600);
+});
+
+test("workspace.describe publishes max_envelope_bytes", () => {
+  const c = new Coordinator({});
+  c.dispatch({ jsonrpc: "2.0", id: "1", method: "workspace.create", params: { workspace: "w" } });
+  const d = c.dispatch({ jsonrpc: "2.0", id: "2", method: "workspace.describe", params: { workspace: "w" } });
+  assert.equal((d.result as { max_envelope_bytes: number }).max_envelope_bytes, 1048576);
+});


### PR DESCRIPTION
Closes #107.

Adds a `max_envelope_bytes` option (default 1 MiB per §4.4), rejects an oversized envelope at dispatch with `-32600`, and publishes the value in the workspace descriptor. Size is measured with the shared canonicaliser so the two references agree; an envelope that cannot be canonicalised falls through to the existing ingress rejection (this avoided breaking the ingress-canonicalisation tests, where a deliberately invalid number must still return `-32602`).

Regression tests: an oversized envelope → `-32600`; `workspace.describe` publishes `max_envelope_bytes`. Both fail on pre-fix `main`. Full suites green (Python 241, TS 190), typecheck clean.