### PR TITLE
Fail closed with SIG_VERIFY_FAILED on a verification exception

### DIFF
--- a/packages/coordinator-py/tests/test_identity_and_signed.py
+++ b/packages/coordinator-py/tests/test_identity_and_signed.py
@@ -414,3 +414,21 @@ def test_rotated_out_key_cannot_sign_live_via_backdated_ts():
                       "input": {}, "assignee": "agent:bot", "ts": k1.valid_from}}
     _sign_envelope(sk1, env, "k1")
     assert c.dispatch(env)["error"]["code"] == -32071  # SIG_KEY_NOT_FOUND
+
+
+def test_unverifiable_signature_fails_closed():
+    c = Coordinator(CoordinatorOptions(require_signatures=True))
+    c.dispatch({"jsonrpc": "2.0", "id": "1", "method": "workspace.create",
+                "params": {"workspace": "w"}})
+    # A structurally valid JWK whose x decodes to the wrong length, so building
+    # the public key throws during verification.
+    c.dispatch({"jsonrpc": "2.0", "id": "2", "method": "participant.join",
+                "params": {"workspace": "w", "from": "human:alice", "type": "human",
+                           "jwks": {"keys": [{"kty": "OKP", "crv": "Ed25519",
+                                              "kid": "k1", "x": "AA"}]},
+                           "profiles": ["core/1.0", "security-signed/1.0"]}})
+    env = {"jsonrpc": "2.0", "id": "3", "method": "task.create",
+           "params": {"workspace": "w", "from": "human:alice", "kind": "k",
+                      "input": {}, "assignee": "human:alice"},
+           "sig": "ed25519:k1:AAAA"}
+    assert c.dispatch(env)["error"]["code"] == -32070  # SIG_VERIFY_FAILED

--- a/packages/coordinator/src/coordinator.ts
+++ b/packages/coordinator/src/coordinator.ts
@@ -624,9 +624,11 @@ export class Coordinator {
         return rpcError(E.SIG_VERIFY_FAILED, "Signature failed verification");
       }
       return null;
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      return rpcError(E.INTERNAL, `Signature check error: ${msg}`);
+    } catch {
+      // An exception here (malformed key or signature bytes) means the
+      // signature cannot be verified: fail closed with the same generic code
+      // as the Python reference, and do not leak the exception detail.
+      return rpcError(E.SIG_VERIFY_FAILED, "Signature failed verification");
     }
   }
 

--- a/packages/coordinator/tests/identity_and_signed.test.ts
+++ b/packages/coordinator/tests/identity_and_signed.test.ts
@@ -274,3 +274,18 @@ test("a rotated-out key cannot sign live requests via a backdated ts", () => {
   signed(env, k1.sk, k1.jwk.kid);
   assert.equal(c.dispatch(env).error?.code, -32071);  // SIG_KEY_NOT_FOUND
 });
+
+test("a signature that cannot be verified fails closed with SIG_VERIFY_FAILED", () => {
+  const c = new Coordinator({ requireSignatures: true });
+  c.dispatch({ jsonrpc: "2.0", id: "1", method: "workspace.create", params: { workspace: "w" }});
+  // A structurally valid JWK whose x decodes to the wrong length, so building
+  // the public key throws during verification.
+  c.dispatch({ jsonrpc: "2.0", id: "2", method: "participant.join",
+    params: { workspace: "w", from: "human:alice", type: "human",
+              jwks: { keys: [{ kty: "OKP", crv: "Ed25519", kid: "k1", x: "AA" }] },
+              profiles: ["core/1.0", "security-signed/1.0"] }});
+  const env: Envelope = { jsonrpc: "2.0", id: "3", method: "task.create",
+    params: { workspace: "w", from: "human:alice", kind: "k", input: {}, assignee: "human:alice" },
+    sig: "ed25519:k1:AAAA" };
+  assert.equal(c.dispatch(env).error?.code, -32070);  // SIG_VERIFY_FAILED, not INTERNAL
+});


### PR DESCRIPTION
Closes #115.

The TS verifier caught a crypto exception and returned `INTERNAL` (-32603) with the exception message on the wire; the Python reference returns `SIG_VERIFY_FAILED` (-32070) generically. This makes TS match: an unverifiable signature is a verification failure, and the detail is no longer leaked. Regression test in both refs (malformed JWK `x` → verify throws → -32070); fails on pre-fix TS. Full suites green (Python 240, TS 189), typecheck clean.