### PR TITLE
Add a Docker image that launches the MCP server over stdio

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+# Keep the build context small. Nothing here is copied by either Dockerfile,
+# and node_modules in particular is large and platform-specific: the root
+# Dockerfile runs its own npm install inside the image.
+.git
+.github
+**/node_modules
+**/.venv
+**/__pycache__
+**/*.pyc
+**/*.egg-info
+.pytest_cache
+.mypy_cache
+.ruff_cache
+
+# Local state written by the demos and the starter.
+**/.data
+**/*.db
+**/*.db-shm
+**/*.db-wal
+**/*.log
+
+# Documentation assets, not needed to build or run either image.
+docs
+diagrams

--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -1,0 +1,43 @@
+# The CHAP MCP server, over stdio.
+#
+# This is the image a directory or an MCP client builds to launch and inspect
+# the server. It reproduces what the registry entry advertises,
+#
+#   npx -y @brightbeamai/chap-coordinator-mcp
+#
+# so what an inspector sees here is what a user gets. The root `Dockerfile`
+# builds something else: the playground, a web UI on port 8080. An inspector
+# pointed at that finds an HTTP server rather than a tool list.
+#
+#   docker build -f Dockerfile.mcp -t chap-mcp .
+#   docker run --rm -i chap-mcp
+#
+# The server speaks JSON-RPC on stdin and stdout and logs to stderr, so `-i`
+# matters and `-t` must not be used.
+
+FROM node:20-bookworm-slim
+
+# Pin the release the image serves. Bump on each publish, or override:
+#   docker build -f Dockerfile.mcp --build-arg CHAP_MCP_VERSION=0.2.13 .
+ARG CHAP_MCP_VERSION=0.2.12
+
+# --omit=optional skips better-sqlite3, an optional dependency of the
+# coordinator. A stdio server holds its workspaces in memory for the life of
+# the process and never opens the store, so the native module is dead weight
+# here and its prebuilt binaries are the one thing that could fail the build.
+RUN npm install -g --omit=optional --no-audit --no-fund \
+      "@brightbeamai/chap-coordinator-mcp@${CHAP_MCP_VERSION}" \
+    && npm cache clean --force
+
+# Persist workspaces by mounting a volume here and setting CHAP_DB_PATH.
+# Left unset, the coordinator runs in memory and a restart starts clean.
+ENV CHAP_DB_PATH=""
+
+# Comma-separated profile set for new workspaces. Unset means Core plus
+# review, whisper, deliberation, handoff, control, routing, modes and
+# audit-scitt.
+ENV CHAP_PROFILES=""
+
+USER node
+
+ENTRYPOINT ["chap-mcp-server"]


### PR DESCRIPTION
The root Dockerfile builds the playground, a web UI on port 8080. A directory or client that builds this repository to inspect the MCP server finds an HTTP server rather than a tool list.

`Dockerfile.mcp` reproduces what the registry entry advertises, `npx -y @brightbeamai/chap-coordinator-mcp`, so an inspector sees what a user gets. The release it serves is a build argument.

Verified against the published 0.2.12 using the image's own install and entrypoint commands: initialize returns `chap 0.2.12`, `tools/list` returns 39 tools, stdout carries protocol only, logging goes to stderr.

`.dockerignore` keeps the build context off node_modules, local databases and documentation assets. Neither Dockerfile copies any of it.